### PR TITLE
Fix gast to resolve Tensorflow conflict

### DIFF
--- a/c3/__init__.py
+++ b/c3/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2dev"
+__version__ = "1.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ pytz==2020.1
 PyYAML==5.3.1
 radon==4.3.2
 requests-oauthlib==1.3.0
+rich==9.2.0
 rsa==4.6
 scipy==1.5.2
 six==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "cma==3.0.3",
         "cython",
         "ipython==7.15.0",
+        "gast==0.3.3",
 	    "hjson==3.0.2",
         "rich==9.2.0",
         "numpy==1.18.5",


### PR DESCRIPTION
# What 
Fix tensorflow installation dependency on Windows. The current release has the following error:
```bash
pip install c3-toolset
.
.
.
tensorflow 2.3.1 requires gast==0.3.3, but you'll have gast 0.4.0 which is incompatible.
```

Closes #4

# Why
New `pip` resolution messes up dependencies for tensorflow.

# How 
Freeze version of `gast` to `0.3.3` to prevent conflicts.

# Notes
Also made some minor fixes:
* Add `rich` to `requirements.txt`
* Fix the version number in `__init__.py`