### PR TITLE
Better CI Job names

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-
+  complexity_check:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  coverage_check_upload:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/format_lint.yml
+++ b/.github/workflows/format_lint.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  format_lint_check:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  integration_unit_tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
# What
Better names for our CI checks

# Why
We are gradually moving towards making CI checks mandatory for PRs to be merged (they aren't a necessary check now and you can merge PRs with failed checks). Currently all our checks had similar names making it difficult to automate this compulsory checks

# How
Update names of Github Actions jobs to be more intuitive with regard to what they do.