### PR TITLE
Qiskit hotfix for Package Build CI

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install c3 package
       run: |
         python -m pip install --upgrade pip
-        pip install pytest-cov qiskit
+        pip install pytest-cov qiskit==0.23.2
         pip install .
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Pin `qiskit` version in package build CI to fix issues with updated `numpy` compatibility.