### PR TITLE
Minor qiskit fixes

### DIFF
--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -19,7 +19,7 @@ from .c3_exceptions import C3QiskitError
 from .c3_job import C3Job
 from .c3_backend_utils import get_init_ground_state, get_sequence
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 from abc import ABC, abstractclassmethod, abstractmethod
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,29 @@ class C3QasmSimulator(Backend, ABC):
             for all device parameters for simulation
         """
         self._device_config = config_file
+
+    def get_labels(self) -> List[str]:
+        """Return state labels for the system
+
+        Returns
+        -------
+        List[str]
+            A list of state labels in hex format ::
+
+                labels = ['0x1', ...]
+
+        """
+        labels = [
+            hex(i)
+            for i in range(
+                0,
+                pow(
+                    self._number_of_levels,
+                    self._number_of_qubits,
+                ),
+            )
+        ]
+        return labels
 
     def run(self, qobj: qobj.Qobj, **backend_options) -> C3Job:
         """Parse and run a Qobj
@@ -368,19 +391,10 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
         shots_data = (np.round(pop_t.T[-1] * shots)).astype("int32")
 
         # generate state labels
-        labels = [
-            hex(i)
-            for i in range(
-                0,
-                pow(
-                    self._number_of_levels,
-                    self._number_of_qubits,
-                ),
-            )
-        ]
+        output_labels = self.get_labels()
 
         # create results dict
-        counts = dict(zip(labels, shots_data))
+        counts = dict(zip(output_labels, shots_data))
 
         # keep only non-zero states
         counts = dict(filter(lambda elem: elem[1] != 0, counts.items()))
@@ -425,7 +439,7 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         "max_shots": 65536,
         "coupling_map": None,
         "description": "A physics based c3 simulator for qasm experiments",
-        "basis_gates": ["u3", "cx", "id", "x"],
+        "basis_gates": [],
         "gates": [],
     }
 
@@ -495,15 +509,17 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         exp = Experiment()
         exp.quick_setup(self._device_config)
         pmap = exp.pmap
-        model = pmap.model
+        model = pmap.model  # noqa
 
         # initialise parameters
-        # TODO get n_qubits from device config and raise error if mismatch
-        self._number_of_qubits = experiment.config.n_qubits
-        # TODO ensure number of quantum and classical bits is same
-        shots = self._shots
-        # TODO get Hilbert dimensions from device config
-        self._number_of_levels = 2
+        self._number_of_qubits = len(pmap.model.subsystems)
+        if self._number_of_qubits != experiment.config.n_qubits:
+            raise C3QiskitError("Number of qubits in Circuit & Device dont match")
+
+        shots = self._shots  # noqa
+
+        # TODO (Check) Assume all qubits have same Hilbert dims
+        self._number_of_levels = pmap.model.dims[0]
 
         # Validate the dimension of initial statevector if set
         self._validate_initial_statevector()
@@ -513,46 +529,17 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         seed_simulator = 2441129
 
         # convert qasm instruction set to c3 sequence
-        sequence = get_sequence(experiment.instructions, self._number_of_qubits)
+        sequence = get_sequence(experiment.instructions, self._number_of_qubits)  # noqa
 
-        # TODO extend evaluate() and process() for perfect gates and use here
-        exp.get_gates()
-        dUs = exp.dUs
-        # TODO Implement extracting n_qubits and n_levels from device
-        # create initial state for qubits and levels
-        psi_init = get_init_ground_state(self._number_of_qubits, self._number_of_levels)
-        psi_t = psi_init.numpy()
-        pop_t = exp.populations(psi_t, model.lindbladian)
-
-        # simulate sequence
-        for gate in sequence:
-            for du in dUs[gate]:
-                psi_t = np.matmul(du.numpy(), psi_t)
-                pops = exp.populations(psi_t, model.lindbladian)
-                pop_t = np.append(pop_t, pops, axis=1)
+        # TODO get_init_ground_state(), get_gates(), evaluate(), process()
 
         # generate shots style readout with no SPAM
-        # TODO a more sophisticated readout/measurement routine
-        shots_data = (np.round(pop_t.T[-1] * shots)).astype("int32")
+        # TODO a sophisticated readout/measurement routine
 
-        # generate state labels
-        # TODO use n_qubits and n_levels
-        labels = [
-            hex(i)
-            for i in range(
-                0,
-                pow(
-                    self._number_of_levels,
-                    self._number_of_qubits,
-                ),
-            )
-        ]
+        # TODO generate state labels using get_labels()
 
-        # create results dict
-        counts = dict(zip(labels, shots_data))
-
-        # keep only non-zero states
-        counts = dict(filter(lambda elem: elem[1] != 0, counts.items()))
+        # TODO create results dict and remove empty states
+        counts = {}  # type: ignore
 
         end = time.time()
 

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -439,7 +439,7 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         "max_shots": 65536,
         "coupling_map": None,
         "description": "A physics based c3 simulator for qasm experiments",
-        "basis_gates": [],
+        "basis_gates": [],  # TODO add basis gates
         "gates": [],
     }
 

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -256,7 +256,7 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
         "max_shots": 65536,
         "coupling_map": None,
         "description": "A c3 simulator for qasm experiments with perfect gates",
-        "basis_gates": ["cx", "cy", "cz", "iSwap", "id", "x", "y", "z"],
+        "basis_gates": ["cx", "cz", "iSwap", "id", "x", "y", "z"],
         "gates": [],
     }
 

--- a/c3/qiskit/c3_backend_utils.py
+++ b/c3/qiskit/c3_backend_utils.py
@@ -15,6 +15,8 @@ GATE_MAP = {
     "CNOT": "CRXp",
     "CX": "CRXp",
     "cx": "CRXp",
+    "CZ": "CRZp",
+    "cz": "CRZp",
     "I": "Id",
     "u0": "Id",
     "id": "Id",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,7 +65,7 @@ def get_6_qubit_circuit() -> QuantumCircuit:
     qc = QuantumCircuit(6, 6)
     qc.x(0)
     qc.cx(0, 1)
-    qc.measure([0], [0])
+    qc.measure([0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5])
     return qc
 
 

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -85,6 +85,10 @@ def test_get_result(get_6_qubit_circuit, backend, get_result_qiskit):  # noqa
     job_sim = execute(qc, received_backend, shots=1000)
     result_sim = job_sim.result()
     expected_counts = get_result_qiskit[backend]
+
+    # TODO C3: 110000 -> Qiskit: 000011
+    # qiskit_simulator = Aer.get_backend('qasm_simulator')
+    # expected_counts = execute(qc, qiskit_simulator, shots=1000).result().get_counts(qc)
     assert result_sim.get_counts(qc) == expected_counts
 
 


### PR DESCRIPTION
# What
Added some minor qiskit fixes while working on QAOA implementation with our simulator

# Why
General improvements in code structure

# How
* Update gateset for perfect simulator
* Added a get_labels utility function
* Cleaned up framework for physics simulator and add `TODO` where required
* Update tests to measure all qubits
* Include note about difference in qubit numbering in qiskit and C3

# Note
Further developments on qiskit integration (physics simulator, qaoa, OpenPulse etc) are currently suspended pending the completion of the following:
* Better naming scheme for gates, possibly adopting OpenQasm style `{"name": "u2", "qubits": [0], "params": [0.4,0.2]}`
* Parametric gates in perfect gates and physics unitaries
* Improvements on `evaluate()` and `process()` in `Experiment` class
* Virtual Z gates
