### PR TITLE
Flip state labels to match Qiskit style basis vector ordering

### DIFF
--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -17,7 +17,7 @@ from c3.experiment import Experiment
 
 from .c3_exceptions import C3QiskitError
 from .c3_job import C3Job
-from .c3_backend_utils import get_init_ground_state, get_sequence
+from .c3_backend_utils import get_init_ground_state, get_sequence, flip_labels
 
 from typing import Any, Dict, List
 from abc import ABC, abstractclassmethod, abstractmethod
@@ -81,6 +81,14 @@ class C3QasmSimulator(Backend, ABC):
             )
         ]
         return labels
+
+    def disable_flip_labels(self) -> None:
+        """Disable flipping of labels
+        State Labels are flipped before returning results
+        to match Qiskit style qubit indexing convention
+        This function allows disabling of the flip
+        """
+        self._flip_labels = False
 
     def run(self, qobj: qobj.Qobj, **backend_options) -> C3Job:
         """Parse and run a Qobj
@@ -306,6 +314,7 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
         self._qobj_config = None
         # TEMP
         self._sample_measure = False
+        self._flip_labels = True
 
     @classmethod
     def _default_options(cls) -> Options:
@@ -330,7 +339,7 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
             "shots": number of shots used in the simulation
             "data":
                 {
-                "counts": {'0x9: 5, ...},
+                "counts": {'0x9': 5, ...},
                 "memory": ['0x9', '0xF', '0x1D', ..., '0x9']
                 },
             "status": status string for the simulation
@@ -398,6 +407,10 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
 
         # keep only non-zero states
         counts = dict(filter(lambda elem: elem[1] != 0, counts.items()))
+
+        # flipping state labels to match qiskit qubit indexing convention
+        if self._flip_labels:
+            counts = flip_labels(counts)
 
         end = time.time()
 

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -408,7 +408,8 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
         # keep only non-zero states
         counts = dict(filter(lambda elem: elem[1] != 0, counts.items()))
 
-        # flipping state labels to match qiskit qubit indexing convention
+        # flipping state labels to match qiskit style qubit indexing convention
+        # default is to flip labels to qiskit style, use disable_flip_labels()
         if self._flip_labels:
             counts = flip_labels(counts)
 
@@ -553,6 +554,11 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
 
         # TODO create results dict and remove empty states
         counts = {}  # type: ignore
+
+        # flipping state labels to match qiskit style qubit indexing convention
+        # default is to flip labels to qiskit style, use disable_flip_labels()
+        if self._flip_labels:
+            counts = flip_labels(counts)
 
         end = time.time()
 

--- a/c3/qiskit/c3_backend_utils.py
+++ b/c3/qiskit/c3_backend_utils.py
@@ -1,6 +1,6 @@
 """Convenience Module for creating different c3_backend
 """
-from typing import List
+from typing import Dict, List
 import tensorflow as tf
 import math
 from .c3_exceptions import C3QiskitError
@@ -155,3 +155,8 @@ def get_init_ground_state(n_qubits: int, n_levels: int) -> tf.Tensor:
     init_state = tf.transpose(tf.constant(psi_init, tf.complex128))
 
     return init_state
+
+
+def flip_labels(counts: Dict[str, int]) -> Dict[str, int]:
+    labels_flipped = counts
+    return labels_flipped

--- a/c3/qiskit/c3_backend_utils.py
+++ b/c3/qiskit/c3_backend_utils.py
@@ -158,6 +158,34 @@ def get_init_ground_state(n_qubits: int, n_levels: int) -> tf.Tensor:
 
 
 def flip_labels(counts: Dict[str, int]) -> Dict[str, int]:
+    """Flip C3 qubit labels to match Qiskit qubit indexing
+
+    Parameters
+    ----------
+    counts : Dict[str, int]
+        OpenQasm 2.0 result counts with original C3 style
+        qubit indices
+
+    Returns
+    -------
+    Dict[str, int]
+        OpenQasm 2.0 result counts with Qiskit style labels
+
+    Note
+    ----
+    Basis vector ordering in Qiskit
+
+    Qiskit uses a slightly different ordering of the qubits compared to
+    what is seen in Physics textbooks. In qiskit, the qubits are represented from
+    the most significant bit (MSB) on the left to the least significant bit (LSB)
+    on the right (big-endian). This is similar to bitstring representation
+    on classical computers, and enables easy conversion from bitstrings to
+    integers after measurements are performed.
+
+    More details:
+    https://qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations.html#Basis-vector-ordering-in-Qiskit
+
+    """
     labels_flipped_counts = {}
     for key, value in counts.items():
         key_bin = bin(int(key, 0))

--- a/c3/qiskit/c3_backend_utils.py
+++ b/c3/qiskit/c3_backend_utils.py
@@ -158,5 +158,10 @@ def get_init_ground_state(n_qubits: int, n_levels: int) -> tf.Tensor:
 
 
 def flip_labels(counts: Dict[str, int]) -> Dict[str, int]:
-    labels_flipped = counts
-    return labels_flipped
+    labels_flipped_counts = {}
+    for key, value in counts.items():
+        key_bin = bin(int(key, 0))
+        key_bin_rev = "0b" + key_bin[:1:-1]
+        key_rev = hex(int(key_bin_rev, 0))
+        labels_flipped_counts[key_rev] = value
+    return labels_flipped_counts

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -6,7 +6,7 @@ from c3.qiskit.c3_exceptions import C3QiskitError
 from qiskit.quantum_info import Statevector
 from qiskit import transpile
 from qiskit.providers import BackendV1 as Backend
-from qiskit import execute
+from qiskit import execute, Aer
 from qiskit.transpiler.exceptions import TranspilerError
 
 import pytest
@@ -84,12 +84,18 @@ def test_get_result(get_6_qubit_circuit, backend, get_result_qiskit):  # noqa
     qc = get_6_qubit_circuit
     job_sim = execute(qc, received_backend, shots=1000)
     result_sim = job_sim.result()
-    expected_counts = get_result_qiskit[backend]
 
-    # TODO C3: 110000 -> Qiskit: 000011
-    # qiskit_simulator = Aer.get_backend('qasm_simulator')
-    # expected_counts = execute(qc, qiskit_simulator, shots=1000).result().get_counts(qc)
-    assert result_sim.get_counts(qc) == expected_counts
+    # Test results with qiskit style qubit indexing
+    qiskit_simulator = Aer.get_backend("qasm_simulator")
+    qiskit_counts = execute(qc, qiskit_simulator, shots=1000).result().get_counts(qc)
+    assert result_sim.get_counts(qc) == qiskit_counts
+
+    # Test results with original C3 style qubit indexing
+    received_backend.disable_flip_labels()
+    no_flip_counts = get_result_qiskit[backend]
+    job_sim = execute(qc, received_backend, shots=1000)
+    result_sim = job_sim.result()
+    assert result_sim.get_counts() == no_flip_counts
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# What
Closes #58 

# Why
Issues are bad, should fix

# How
* Add new private variable `_flip_labels` in `C3QasmSimulator` which tracks whether qubit labels are to be flipped
* Add function `disable_flip_labels()` which disables the default behaviour to flip qubit state labels when generating experiment results in the qiskit-c3 interface
* Add `c3_backend_utils` function `flip_labels()` which flips state labels after experiment data is collected
* Updated tests to check for both qiskit style and original c3 style results in c3-qiskit experiment data
* Added notes in docstrings with details and links