### PR TITLE
Better Release and CI pipelines

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install c3 package
       run: |
         python -m pip install --upgrade pip
-        pip install pytest-cov qiskit==0.23.2
+        pip install pytest-cov pytest-xdist qiskit==0.23.2
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/nightly_pypi.yml
+++ b/.github/workflows/nightly_pypi.yml
@@ -37,3 +37,28 @@ jobs:
       with:
         password: ${{ secrets.pypi_password }}
         skip_existing: true
+    - name: Wait for 3 minutes
+      uses: juliangruber/sleep-action@v1
+      with:
+          time: 3m
+
+  check-pip-install:
+    needs: [nightly_build-and-publish]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install c3-toolset-nightly from pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install c3-toolset-nightly

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - dev
+      - master
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -33,3 +33,28 @@ jobs:
       with:
         password: ${{ secrets.pypi_password }}
         skip_existing: true
+    - name: Wait for 3 minutes
+      uses: juliangruber/sleep-action@v1
+      with:
+          time: 3m
+
+  check-pip-install:
+    needs: [build-and-publish]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install c3-toolset from pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install c3-toolset

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches:
-      - master
       - dev
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ source env/bin/activate
 pip install -e .
 ```
 
-This will create an editable installation of `c3-toolset` in the `c3-dev` or `env` environment which is linked to your local `c3/` directory making sure that any changes you make to the code are automatically included. For development purposes, you will probably want to additionally install `jupyter`, `notebook`,  `matplotlib`, `pytest`, and `pytest-cov`. If you wish to use Qiskit with C3, you must also install `qiskit==0.23`.
+This will create an editable installation of `c3-toolset` in the `c3-dev` or `env` environment which is linked to your local `c3/` directory making sure that any changes you make to the code are automatically included. For development purposes, you will probably want to additionally install `jupyter`, `notebook`,  `matplotlib`, `pytest`, `pytest-xdist` and `pytest-cov`. If you wish to use Qiskit with C3, you must also install `qiskit==0.23.2`.
 
 ## Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The C3 package is intended to close the loop between open-loop control optimizat
 pip install c3-toolset
 ```
 
+If you want to try out the bleeding edge (possibly buggy) version under development:
+
+```bash
+pip install c3-toolset-nightly
+```
+
+## Usage
+
 C3  provides a simple Python API through which it may integrate with virtually any experimental setup.
 Contact us at [c3@q-optimize.org](mailto://quantum.c3po@gmail.com).
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers
+addopts = --strict-markers -nauto
 markers =
     integration: marks integration tests (deselect with '-m "not integration"')
     unit: marks unit tests (deselect with '-m "not unit"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ hjson==3.0.2
 numpy==1.19.5
 pre-commit==2.7.1
 pytest-cov==2.10
+pytest-xdist==2.2.1
 python-dateutil==2.8.1
 qiskit==0.23.2
 radon==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gast==0.3.3
 hjson==3.0.2
 numpy==1.19.5
 pre-commit==2.7.1
-pytest-cov==2.10
+pytest-cov==2.11.1
 pytest-xdist==2.2.1
 python-dateutil==2.8.1
 qiskit==0.23.2


### PR DESCRIPTION
# What
Faster and more robust CI checks

# Why
Time taken by test suite is gradually increasing. Cross-platform builds and dependencies require more nuanced testing.

# How
* Speed up tests with multiprocessing. This is done with `pytest-xdist`
* The pip resolver differently handles `pip install -e .` and `pip install <package-name>`. As such, certain dependency resolution conflicts might crop up after release to `pip`. Added a CI that checks `pip` released packages install fine on all supported platforms - by directly installing from `pip`. This is a regression test for #5 and #4
* Stable Release to `pip` is now *only* possible when pushing to master with the version numbers duly updated
* Added note on nightly release to README.