### PR TITLE
Make parallel testing flexible

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -30,7 +30,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 --cov-report=xml test/
+        pytest -v --cov=c3 --cov-report=xml test/ -n=auto
     - name: Upload build stats to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 --cov-report=xml test/
+        pytest -v --cov=c3 --cov-report=xml test/ -n=auto
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -29,4 +29,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 test/
+        pytest -v --cov=c3 test/ -n=auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers -nauto
+addopts = --strict-markers
 markers =
     integration: marks integration tests (deselect with '-m "not integration"')
     unit: marks unit tests (deselect with '-m "not unit"')


### PR DESCRIPTION
# What
Make parallel testing flexible for devs with and without `pytest-xdist`

# Why
Using `-nauto` in `pytest.ini` (as introduced in #62) would break tests for users without `pytest-xdist` installed and the error message is not particularly intuitive

# How
* Remove `-nauto` from `pytest.ini`
* Add explicit `-n=auto` to CI workflows

# Note
If someone wants to parallelize their testing:

```bash
pip install pytest-xdist
pytest -vv test/ -n=auto
```

When creating a new development environment, `pytest-xdist` is included by default in the `requirements.txt`