### PR TITLE
Deprecation decorator and minor code cleanups

### DIFF
--- a/c3/generator/devices.py
+++ b/c3/generator/devices.py
@@ -1101,7 +1101,6 @@ class AWG(Device):
         inphase_comps = []
         quadrature_comps = []
 
-        amp_tot_sq = 0
         for comp in components[chan].values():
             if isinstance(comp, Envelope):
                 amp_tot_sq += 1

--- a/c3/libraries/envelopes.py
+++ b/c3/libraries/envelopes.py
@@ -8,6 +8,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 from c3.c3objs import Quantity as Qty
+from c3.utils.utils import deprecated
 
 envelopes = dict()
 
@@ -296,6 +297,7 @@ def gaussian_sigma(t, params):
     return (gauss - offset) / norm
 
 
+@deprecated("Using standard width. Better use gaussian_sigma().")
 @env_reg_deco
 def gaussian(t, params):
     """
@@ -307,7 +309,6 @@ def gaussian(t, params):
         t_final : float
             Total length of the Gaussian.
     """
-    DeprecationWarning("Using standard width. Better use gaussian_sigma.")
     params["sigma"] = Qty(
         value=params["t_final"].get_value() / 6,
         min_val=params["t_final"].get_value() / 8,
@@ -429,10 +430,10 @@ def drag_sigma(t, params):
     return (drag - offset) ** 2 / norm
 
 
+@deprecated("Using standard width. Better use drag_sigma.")
 @env_reg_deco
 def drag(t, params):
     """Second order gaussian with fixed time/sigma ratio."""
-    DeprecationWarning("Using standard width. Better use drag_sigma.")
     params["sigma"] = Qty(
         value=params["t_final"].get_value() / 4,
         min_val=params["t_final"].get_value() / 8,

--- a/c3/utils/utils.py
+++ b/c3/utils/utils.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 from tensorflow.python.framework import ops
 from typing import Tuple
+import warnings
 
 
 # SYSTEM AND SETUP
@@ -119,3 +120,36 @@ def jsonify_list(data):
         return data.numpy().tolist()
     else:
         return data
+
+
+def deprecated(message: str):
+    """Decorator for deprecating functions
+
+    Parameters
+    ----------
+    message : str
+        Message to display along with DeprecationWarning
+
+    Examples
+    --------
+    Add a :code:`@deprecated("message")` decorator to the function::
+
+        @deprecated("Using standard width. Better use gaussian_sigma.")
+        def gaussian(t, params):
+            ...
+
+    """
+
+    def deprecated_decorator(func):
+        def deprecated_func(*args, **kwargs):
+            warnings.warn(
+                "{} is a deprecated function. {}".format(func.__name__, message),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            warnings.simplefilter("default", DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return deprecated_func
+
+    return deprecated_decorator


### PR DESCRIPTION
* Fix deprecation warnings with a decorator, usage `@deprecated("message")`
* Remove repeated variable initialisation

# Note
Going ahead, if we need more sophisticated deprecation handling, some useful resources are here:
* https://stackoverflow.com/questions/2536307/decorators-in-the-python-standard-lib-deprecated-specifically
* https://pypi.org/project/Deprecated/
* https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/deprecation.py