### PR TITLE
Hotfix: release pipeline

### DIFF
--- a/.github/workflows/nightly_pypi.yml
+++ b/.github/workflows/nightly_pypi.yml
@@ -17,8 +17,9 @@ jobs:
         python-version: 3.7
     - name : Install Prerequisites
       run : |
+        sudo apt-add-repository universe
+        sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
-        sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
         pip3 install wheel
     - name : Update Version numbers

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,8 +16,9 @@ jobs:
         python-version: 3.7
     - name : Install Prerequisites
       run : |
+        sudo apt-add-repository universe
+        sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
-        sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
         pip3 install wheel
     - name: Build sdist and bdist_wheel


### PR DESCRIPTION
Python 2 is no longer available by default in apt repositories starting from Ubuntu 20.04

Unused `python-pip` in the release workflows is removed in this PR to fix breaking CD pipeline.