### PR TITLE
Efficient testing

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -30,12 +30,5 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 --cov-report=xml test/
-    - name: Upload build stats to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        env_vars: OS,PYTHON
-        name: build-c3
-        fail_ci_if_error: false
-        verbose: true
+        pytest -v -x -m "not slow" test/
+        pytest -v -x -m "slow" test/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 --cov-report=xml test/
+        pytest -x -v --cov=c3 --cov-report=xml test/
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -29,4 +29,5 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
-        pytest -v --cov=c3 test/
+        pytest -v -x -m "not slow" test/
+        pytest -v -x -m "slow" test/

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -565,7 +565,7 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         seed_simulator = 2441129
 
         # convert qasm instruction set to c3 sequence
-        sequence = get_sequence(experiment.instructions, self._number_of_qubits)  # noqa
+        sequence = get_sequence(experiment.instructions)  # noqa
 
         # TODO get_init_ground_state(), get_gates(), evaluate(), process()
 

--- a/c3/qiskit/c3_backend_utils.py
+++ b/c3/qiskit/c3_backend_utils.py
@@ -1,6 +1,6 @@
 """Convenience Module for creating different c3_backend
 """
-from typing import Any, Dict, List
+from typing import Dict, List
 import numpy as np
 import tensorflow as tf
 import math
@@ -103,7 +103,7 @@ def get_sequence(instructions: List) -> List[str]:
     return sequence
 
 
-def make_gate_str(instruction: Dict[str, Any], gate_name: str) -> str:
+def make_gate_str(instruction: dict, gate_name: str) -> str:
     """Make C3 style gate name string
 
     Parameters
@@ -122,7 +122,7 @@ def make_gate_str(instruction: Dict[str, Any], gate_name: str) -> str:
 
             {"name": "rx", "qubits": [0], "params": [1.57]} -> rx90p[0]
     """
-    qubits = instruction.qubits
+    qubits = instruction.qubits  # type: ignore
     gate_str = gate_name + str(qubits)
     return gate_str
 

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -98,7 +98,6 @@ def test_get_result(get_6_qubit_circuit, backend, get_result_qiskit):  # noqa
 
 @pytest.mark.unit
 @pytest.mark.qiskit
-@pytest.mark.xfail(raises=C3QiskitError)
 @pytest.mark.slow
 @pytest.mark.parametrize("backend", ["c3_qasm_perfect_simulator"])
 def test_get_exception(get_bad_circuit, backend):  # noqa
@@ -115,6 +114,6 @@ def test_get_exception(get_bad_circuit, backend):  # noqa
     received_backend = c3_qiskit.get_backend(backend)
     received_backend.set_device_config("test/quickstart.hjson")
     qc = get_bad_circuit
-    job_sim = execute(qc, received_backend, shots=1000)
-    result_sim = job_sim.result()
-    assert result_sim.get_counts(qc) == {}
+
+    with pytest.raises(C3QiskitError):
+        execute(qc, received_backend, shots=1000)

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -98,7 +98,6 @@ def test_get_result(get_6_qubit_circuit, backend, get_result_qiskit):  # noqa
 
 @pytest.mark.unit
 @pytest.mark.qiskit
-@pytest.mark.slow
 @pytest.mark.parametrize("backend", ["c3_qasm_perfect_simulator"])
 def test_get_exception(get_bad_circuit, backend):  # noqa
     """Test to check exceptions


### PR DESCRIPTION
# What
Fail fast in testing and run slower tests after quicker tests

# Why
Fixes #77 

# How
* Using `pytest` with the `-x` flag makes sure that testing will abort on the first failure. This has now been integrated into all the tests being run on the CI pipeline. For local testing, developers should add that flag when calling the `pytest` CLI
* We already mark some of our tests as `slow` based on expectations that these require more compute/time. The CI has now been modified to first run tests that are not marked as slow and only then run the slow tests (along with the fail fast described above). For local testing, developers should call `pytest` with the `-m "not slow"` flag to run the quicker tests first and can then run with the `-m "slow"` flag. 
