### PR TITLE
Update Black version in Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
     - id: black
       language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docstr-coverage==1.2.0
 gast==0.3.3
 hjson==3.0.2
 numpy==1.19.5
-pre-commit==2.7.1
+pre-commit==2.13.0
 pytest-cov==2.11.1
 pytest-xdist==2.2.1
 python-dateutil==2.8.1


### PR DESCRIPTION
# What
Update `black` version in `pre-commit` hooks

# Why
Fix for https://github.com/psf/black/issues/1629 included in version [21.4b0](https://github.com/psf/black/releases/tag/21.4b0) and above

# How
Bump `black` version in `.pre-commit-config.yaml`

# Note on updating your workflows

Once this PR is merged, please perform the following steps to make sure your commit hooks and workflows use the latest black version:

### stash your WIP changes in the current working branch
`git stash push -m "WIP on <branch-name> <short status>"`

### pull latest `dev` to get updated `pre-commit` hooks
* `git checkout dev`
* `git pull upstream dev` assuming you are working in a forked repo
* `pip install --upgrade pip`
* `pip install --upgrade pre-commit`

### merge, install and use updated hooks on your WIP branch
* `git checkout <branch-name>`
* `git merge dev`
* `pre-commit install`
* `git stash pop`
* `git add <files>`
* `git commit -m <message>`

At this point, pre-commit hook should automatically update its dependencies to reflect your updated config file. This will usually take a few minutes.