### PR TITLE
Fix API mismatch in Tensorflow Optimizers

### DIFF
--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -280,7 +280,7 @@ def tf_sgd(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
-    iters = options["maxfun"]
+    iters = options["maxiters"]  # TF based optimizers use algo iters not fevals
 
     var = tf.Variable(x_init)
 

--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -6,7 +6,7 @@ optional arguments.
 from scipy.optimize import minimize as minimize
 import cma.evolution_strategy as cma
 import numpy as np
-
+import warnings
 from typing import Callable
 import adaptive
 import copy
@@ -326,6 +326,9 @@ def tf_adam(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
+
+    warnings.warn("The integration of this algorithm is incomplete and incorrect.")
+
     iters = options["maxfun"]
     var = tf.Variable(x_init)
 
@@ -370,6 +373,9 @@ def tf_rmsprop(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
+
+    warnings.warn("The integration of this algorithm is incomplete and incorrect.")
+
     iters = options["maxfun"]
 
     var = tf.Variable(x_init)
@@ -418,6 +424,9 @@ def tf_adadelta(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
+
+    warnings.warn("The integration of this algorithm is incomplete and incorrect.")
+
     iters = options["maxfun"]
 
     var = tf.Variable(x_init)

--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -326,7 +326,7 @@ def tf_adam(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
-
+    # TODO Update maxfun->maxiters, default hyperparameters and error handling
     warnings.warn("The integration of this algorithm is incomplete and incorrect.")
 
     iters = options["maxfun"]
@@ -373,7 +373,7 @@ def tf_rmsprop(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
-
+    # TODO Update maxfun->maxiters, default hyperparameters and error handling
     warnings.warn("The integration of this algorithm is incomplete and incorrect.")
 
     iters = options["maxfun"]
@@ -424,7 +424,7 @@ def tf_adadelta(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
-
+    # TODO Update maxfun->maxiters, default hyperparameters and error handling
     warnings.warn("The integration of this algorithm is incomplete and incorrect.")
 
     iters = options["maxfun"]

--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -291,7 +291,15 @@ def tf_sgd(
     def tf_fun():
         return fun(var)
 
-    opt_sgd = tf.keras.optimizers.SGD(learning_rate=0.1, momentum=0.9)
+    learning_rate = 0.1
+    momentum = 0.9
+
+    if "learning_rate" in options.keys():
+        learning_rate = options["learning_rate"]
+    if "momentum" in options.keys():
+        momentum = options["momentum"]
+
+    opt_sgd = tf.keras.optimizers.SGD(learning_rate=learning_rate, momentum=momentum)
 
     for _ in range(iters):
         step_count = opt_sgd.minimize(tf_fun, [var])

--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -293,7 +293,7 @@ def tf_sgd(
 
     opt_sgd = tf.keras.optimizers.SGD(learning_rate=0.1, momentum=0.9)
 
-    for step in range(iters):
+    for _ in range(iters):
         step_count = opt_sgd.minimize(tf_fun, [var])
         print(f"epoch {step_count.numpy()}: func_value: {tf_fun()}")
 

--- a/c3/libraries/algorithms.py
+++ b/c3/libraries/algorithms.py
@@ -280,6 +280,10 @@ def tf_sgd(
     OptimizeResult
         SciPy OptimizeResult type object with final parameters
     """
+
+    if "maxfun" in options.keys():
+        raise KeyError("Tensorflow Optimizers require a maxiters")
+
     iters = options["maxiters"]  # TF based optimizers use algo iters not fevals
 
     var = tf.Variable(x_init)

--- a/test/test_two_qubits.py
+++ b/test/test_two_qubits.py
@@ -363,6 +363,26 @@ def test_optim_tf_sgd() -> None:
 @pytest.mark.optimizers
 @pytest.mark.slow
 @pytest.mark.integration
+@pytest.mark.tensorflow
+def test_bad_tf_sgd() -> None:
+    bad_tf_opt = C1(
+        dir_path=logdir,
+        fid_func=fidelities.average_infid_set,
+        fid_subspace=["Q1", "Q2"],
+        pmap=pmap,
+        algorithm=algorithms.tf_sgd,
+        options={"maxfun": 2},
+        run_name="better_X90_bad_tf",
+    )
+    bad_tf_opt.set_exp(exp)
+
+    with pytest.raises(KeyError):
+        bad_tf_opt.optimize_controls()
+
+
+@pytest.mark.optimizers
+@pytest.mark.slow
+@pytest.mark.integration
 def test_optim_lbfgs() -> None:
     lbfgs_opt = C1(
         dir_path=logdir,

--- a/test/test_two_qubits.py
+++ b/test/test_two_qubits.py
@@ -315,7 +315,7 @@ opt = C1(
     fid_subspace=["Q1", "Q2"],
     pmap=pmap,
     algorithm=algorithms.tf_sgd,
-    options={"maxfun": 2},
+    options={"maxiters": 5},
     run_name="better_X90_tf_sgd",
 )
 


### PR DESCRIPTION
# What
Update `tf_sgd` to use `maxiters` and include note on WIP TF Optimizers

# Why
Closes #102 and associates

# How
- Add warnings to the `adam`, `adadelta` and `rmsprop` optimizers. These have incomplete/incorrect implementations while some of the default hyper-parameters have been altered without adequate reasoning or comments. Pending further investigations into these algorithms or without the option to alter these hyper-parameters from the user-space, these are essentially buggy and must be avoided. Also added `# TODO`s to make note of what needs to be done
- Updated the `tf_sgd` optimizer to use the correct `maxiters` parameter instead of `maxfun`. This is because these optimizers allow for directly controlling the number of algorithm iterations and not function evaluations.
- Added an Error Handling code in case someone passes `maxfun` to this optimizer
- Provided an option for setting the learning rate and momentum from the user-space
- Added and updated tests to also check for error handling code