### PR TITLE
Add unit tests for qt_utils

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -219,3 +219,10 @@ def get_test_signal() -> Dict:
         "TC1": {"values": tf.linspace(0, 100, 101)},
         "TC2": {"values": tf.linspace(100, 200, 101)},
     }
+
+
+@pytest.fixture()
+def get_test_dimensions() -> list:
+    """Functions in qt_utils that allow arbitrary numbers of dimensions will be tested for all dimensions in this
+    list."""
+    return [3, 5, 10, 50]

--- a/test/test_qt_utils.py
+++ b/test/test_qt_utils.py
@@ -3,7 +3,7 @@ Test Module for qt_utils
 """
 import numpy as np
 import pytest
-from c3.utils.qt_utils import basis, xy_basis, get_basis_matrices
+from c3.utils.qt_utils import basis, xy_basis, get_basis_matrices, rotation, np_kron_n
 from numpy.testing import assert_array_almost_equal as almost_equal
 
 
@@ -59,3 +59,35 @@ def test_basis_matrices() -> None:
         # normalisation
         for a in matrices:
             almost_equal(np.linalg.norm(np.multiply(a, a)), 1)
+
+
+@pytest.mark.unit
+def test_rotation() -> None:
+    """Testing properties of general rotation matrix"""
+    phase = 2 * np.pi * np.random.random()
+    xyz = np.random.random(3)
+    xyz /= np.linalg.norm(xyz)
+    matrix = rotation(phase, xyz)
+
+    almost_equal(np.trace(matrix), 2 * np.cos(0.5 * phase))
+    almost_equal(np.linalg.det(matrix), 1)
+
+
+@pytest.mark.unit
+def test_np_kron_n() -> None:
+    """Testing Kronecker product"""
+    for dim in [3, 5, 10]:
+        A = np.random.rand(dim, dim)
+        B = np.random.rand(dim, dim)
+        C = np.random.rand(dim, dim)
+        D = np.random.rand(dim, dim)
+
+        # associativity and mixed product
+        almost_equal(np_kron_n([A, B + C]), np_kron_n([A, B]) + np_kron_n([A, C]))
+        almost_equal(np_kron_n([A, B]) * np_kron_n([C, D]), np_kron_n([A * C, B * D]))
+        # trace and determinant
+        almost_equal(np.trace(np_kron_n([A, B])), np.trace(A) * np.trace(B))
+        almost_equal(
+            np.linalg.det(np_kron_n([A, B])),
+            np.linalg.det(A) ** dim * np.linalg.det(B) ** dim,
+        )

--- a/test/test_qt_utils.py
+++ b/test/test_qt_utils.py
@@ -23,12 +23,6 @@ from numpy.testing import assert_array_almost_equal as almost_equal
 from c3.libraries.constants import GATES
 
 
-@pytest.fixture()
-def test_dimensions() -> list:
-    """Functions that allow arbitrary numbers of dimensions will be tested for all dimensions in this list."""
-    return [3, 5, 10, 50]
-
-
 @pytest.mark.unit
 def test_pauli_basis() -> None:
     """Testing dimensions of Pauli basis"""
@@ -39,9 +33,9 @@ def test_pauli_basis() -> None:
 
 
 @pytest.mark.unit
-def test_basis(test_dimensions) -> None:
+def test_basis(get_test_dimensions) -> None:
     """Testing orthonormality of basis vectors."""
-    for dim in test_dimensions:
+    for dim in get_test_dimensions:
         pairs = [(i, j) for i in range(dim) for j in range(dim)]
         for (i, j) in pairs:
             vi = basis(dim, i)
@@ -50,11 +44,11 @@ def test_basis(test_dimensions) -> None:
 
 
 @pytest.mark.unit
-def test_xy_basis(test_dimensions) -> None:
+def test_xy_basis(get_test_dimensions) -> None:
     """Testing properties of basis vectors."""
     names = ["x", "y", "z"]
 
-    for dim in test_dimensions:
+    for dim in get_test_dimensions:
         # orthonormality of +/- vectors
         for i in names:
             vi_p = xy_basis(dim, i + "p")
@@ -77,9 +71,9 @@ def test_xy_basis(test_dimensions) -> None:
 
 
 @pytest.mark.unit
-def test_basis_matrices(test_dimensions) -> None:
+def test_basis_matrices(get_test_dimensions) -> None:
     """Testing orthogonality and normalisation of basis matrices."""
-    for dim in test_dimensions[:3]:
+    for dim in get_test_dimensions[:3]:
         matrices = get_basis_matrices(dim)
 
         # orthogonality
@@ -105,9 +99,9 @@ def test_rotation() -> None:
 
 
 @pytest.mark.unit
-def test_np_kron_n(test_dimensions) -> None:
+def test_np_kron_n(get_test_dimensions) -> None:
     """Testing properties of Kronecker product"""
-    for dim in test_dimensions:
+    for dim in get_test_dimensions:
         (A, B, C, D) = [np.random.rand(dim, dim) for _ in range(4)]
 
         # associativity and mixed product
@@ -167,9 +161,9 @@ def test_projector() -> None:
 
 
 @pytest.mark.unit
-def test_pad_matrix(test_dimensions) -> None:
+def test_pad_matrix(get_test_dimensions) -> None:
     """Testing shape, trace, and determinant of matrices after padding"""
-    for dim in test_dimensions:
+    for dim in get_test_dimensions:
         M = np.random.rand(dim, dim)
         padding_dim = np.random.randint(1, 10)
 

--- a/test/test_qt_utils.py
+++ b/test/test_qt_utils.py
@@ -23,6 +23,12 @@ from numpy.testing import assert_array_almost_equal as almost_equal
 from c3.libraries.constants import GATES
 
 
+@pytest.fixture()
+def test_dimensions() -> list:
+    """Functions that allow arbitrary numbers of dimensions will be tested for all dimensions in this list."""
+    return [3, 5, 10, 50]
+
+
 @pytest.mark.unit
 def test_pauli_basis() -> None:
     """Testing dimensions of Pauli basis"""
@@ -33,9 +39,9 @@ def test_pauli_basis() -> None:
 
 
 @pytest.mark.unit
-def test_basis() -> None:
+def test_basis(test_dimensions) -> None:
     """Testing orthonormality of basis vectors."""
-    for dim in [3, 5, 10, 100]:
+    for dim in test_dimensions:
         pairs = [(i, j) for i in range(dim) for j in range(dim)]
         for (i, j) in pairs:
             vi = basis(dim, i)
@@ -44,11 +50,11 @@ def test_basis() -> None:
 
 
 @pytest.mark.unit
-def test_xy_basis() -> None:
+def test_xy_basis(test_dimensions) -> None:
     """Testing properties of basis vectors."""
     names = ["x", "y", "z"]
 
-    for dim in [3, 5, 10, 100]:
+    for dim in test_dimensions:
         # orthonormality of +/- vectors
         for i in names:
             vi_p = xy_basis(dim, i + "p")
@@ -71,9 +77,9 @@ def test_xy_basis() -> None:
 
 
 @pytest.mark.unit
-def test_basis_matrices() -> None:
+def test_basis_matrices(test_dimensions) -> None:
     """Testing orthogonality and normalisation of basis matrices."""
-    for dim in [3, 5, 10]:
+    for dim in test_dimensions[:3]:
         matrices = get_basis_matrices(dim)
 
         # orthogonality
@@ -99,9 +105,9 @@ def test_rotation() -> None:
 
 
 @pytest.mark.unit
-def test_np_kron_n() -> None:
+def test_np_kron_n(test_dimensions) -> None:
     """Testing properties of Kronecker product"""
-    for dim in [3, 5, 10]:
+    for dim in test_dimensions:
         (A, B, C, D) = [np.random.rand(dim, dim) for _ in range(4)]
 
         # associativity and mixed product
@@ -161,9 +167,9 @@ def test_projector() -> None:
 
 
 @pytest.mark.unit
-def test_pad_matrix() -> None:
+def test_pad_matrix(test_dimensions) -> None:
     """Testing shape, trace, and determinant of matrices after padding"""
-    for dim in [3, 5, 10]:
+    for dim in test_dimensions:
         M = np.random.rand(dim, dim)
         padding_dim = np.random.randint(1, 10)
 

--- a/test/test_qt_utils.py
+++ b/test/test_qt_utils.py
@@ -12,10 +12,10 @@ def test_basis() -> None:
     """Testing orthonormality of basis vectors."""
     for dim in [3, 5, 10, 100]:
         pairs = [(i, j) for i in range(dim) for j in range(dim)]
-        for p in pairs:
-            vi = basis(dim, p[0])
-            vj = basis(dim, p[1])
-            almost_equal(vi.T @ vj, 1 if p[0] == p[1] else 0)
+        for (i, j) in pairs:
+            vi = basis(dim, i)
+            vj = basis(dim, j)
+            almost_equal(vi.T @ vj, 1 if i == j else 0)
 
 
 @pytest.mark.unit
@@ -32,6 +32,18 @@ def test_xy_basis() -> None:
             almost_equal(np.linalg.norm(vi_m), 1)
             almost_equal(np.vdot(vi_p.T, vi_m), 0)
 
+        # overlap
+        pairs = [(a, b) for a in names for b in names if b is not a]
+        for (a, b) in pairs:
+            va_p = xy_basis(dim, a + "p")
+            va_m = xy_basis(dim, a + "m")
+            vb_p = xy_basis(dim, b + "p")
+            vb_m = xy_basis(dim, b + "m")
+            almost_equal(np.linalg.norm(np.vdot(va_p.T, vb_p)), 1.0 / np.sqrt(2))
+            almost_equal(np.linalg.norm(np.vdot(va_p.T, vb_m)), 1.0 / np.sqrt(2))
+            almost_equal(np.linalg.norm(np.vdot(va_m.T, vb_p)), 1.0 / np.sqrt(2))
+            almost_equal(np.linalg.norm(np.vdot(va_m.T, vb_m)), 1.0 / np.sqrt(2))
+
 
 @pytest.mark.unit
 def test_basis_matrices() -> None:
@@ -41,8 +53,8 @@ def test_basis_matrices() -> None:
 
         # orthogonality
         pairs = [(a, b) for a in matrices for b in matrices if b is not a]
-        for p in pairs:
-            almost_equal(np.linalg.norm(np.multiply(p[0], p[1])), 0)
+        for (a, b) in pairs:
+            almost_equal(np.linalg.norm(np.multiply(a, b)), 0)
 
         # normalisation
         for a in matrices:

--- a/test/test_qt_utils.py
+++ b/test/test_qt_utils.py
@@ -1,0 +1,49 @@
+"""
+Test Module for qt_utils
+"""
+import numpy as np
+import pytest
+from c3.utils.qt_utils import basis, xy_basis, get_basis_matrices
+from numpy.testing import assert_array_almost_equal as almost_equal
+
+
+@pytest.mark.unit
+def test_basis() -> None:
+    """Testing orthonormality of basis vectors."""
+    for dim in [3, 5, 10, 100]:
+        pairs = [(i, j) for i in range(dim) for j in range(dim)]
+        for p in pairs:
+            vi = basis(dim, p[0])
+            vj = basis(dim, p[1])
+            almost_equal(vi.T @ vj, 1 if p[0] == p[1] else 0)
+
+
+@pytest.mark.unit
+def test_xy_basis() -> None:
+    """Testing properties of basis vectors."""
+    names = ["x", "y", "z"]
+
+    for dim in [3, 5, 10, 100]:
+        # orthonormality of +/- vectors
+        for i in names:
+            vi_p = xy_basis(dim, i + "p")
+            vi_m = xy_basis(dim, i + "m")
+            almost_equal(np.linalg.norm(vi_p), 1)
+            almost_equal(np.linalg.norm(vi_m), 1)
+            almost_equal(np.vdot(vi_p.T, vi_m), 0)
+
+
+@pytest.mark.unit
+def test_basis_matrices() -> None:
+    """Testing properties of basis matrices."""
+    for dim in [3, 5, 10]:
+        matrices = get_basis_matrices(dim)
+
+        # orthogonality
+        pairs = [(a, b) for a in matrices for b in matrices if b is not a]
+        for p in pairs:
+            almost_equal(np.linalg.norm(np.multiply(p[0], p[1])), 0)
+
+        # normalisation
+        for a in matrices:
+            almost_equal(np.linalg.norm(np.multiply(a, a)), 1)


### PR DESCRIPTION
## What
Add tests for `utils/qt_utils.py`

## Why
Part of #92

## How
Adds unit tests for some utility functions in qt_utils, which were not covered by tests yet. 

## Notes
I tried to test the properties of the function's results as described in #71, so that the tests are independent of the function's implementation. For functions which can work with arbitrary dimensions (e.g. `xy_basis`), the test is repeated for some dimensions to be sure, e.g dim=3, 5, 10, 100. Going through all dimensions up to some max value would probably make the test run unnecessary long.
