### PR TITLE
Read and write a model's tasks to config files

### DIFF
--- a/c3/libraries/tasks.py
+++ b/c3/libraries/tasks.py
@@ -6,20 +6,28 @@ import c3.utils.tf_utils as tf_utils
 import c3.utils.qt_utils as qt_utils
 
 
+task_lib = dict()
+
+
+def task_deco(cl):
+    """
+    Decorator for task classes list.
+    """
+    task_lib[str(cl.__name__)] = cl
+    return cl
+
+
 class Task(C3obj):
     # TODO BETTER NAME FOR TASK!
     """Task that is part of the measurement setup."""
 
     def __init__(
-        self,
-        name: str = " ",
-        desc: str = " ",
-        comment: str = " ",
+        self, name: str = " ", desc: str = " ", comment: str = " ", params: dict = None
     ):
-        super().__init__(name=name, desc=desc, comment=comment)
-        self.params = {}
+        super().__init__(name=name, desc=desc, comment=comment, params=params)
 
 
+@task_deco
 class InitialiseGround(Task):
     """Initialise the ground state with a given thermal distribution."""
 
@@ -29,9 +37,11 @@ class InitialiseGround(Task):
         desc: str = " ",
         comment: str = " ",
         init_temp: Quantity = None,
+        params=None,
     ):
-        super().__init__(name=name, desc=desc, comment=comment)
-        self.params["init_temp"] = init_temp
+        super().__init__(name=name, desc=desc, comment=comment, params=params)
+        if init_temp:
+            self.params["init_temp"] = init_temp
 
     def initialise(self, drift_ham, lindbladian=False, init_temp=None):
         """
@@ -78,6 +88,7 @@ class InitialiseGround(Task):
                 return state
 
 
+@task_deco
 class ConfusionMatrix(Task):
     """Allows for misclassificaiton of readout measurement."""
 
@@ -86,9 +97,10 @@ class ConfusionMatrix(Task):
         name: str = "conf_matrix",
         desc: str = " ",
         comment: str = " ",
-        **confusion_rows
+        params=None,
+        **confusion_rows,
     ):
-        super().__init__(name=name, desc=desc, comment=comment)
+        super().__init__(name=name, desc=desc, comment=comment, params=params)
         for qubit, conf_row in confusion_rows.items():
             self.params["confusion_row_" + qubit] = conf_row
 
@@ -117,6 +129,7 @@ class ConfusionMatrix(Task):
         return pops
 
 
+@task_deco
 class MeasurementRescale(Task):
     """
     Rescale the result of the measurements.
@@ -137,10 +150,13 @@ class MeasurementRescale(Task):
         comment: str = " ",
         meas_offset: Quantity = None,
         meas_scale: Quantity = None,
+        params=None,
     ):
-        super().__init__(name=name, desc=desc, comment=comment)
-        self.params["meas_offset"] = meas_offset
-        self.params["meas_scale"] = meas_scale
+        super().__init__(name=name, desc=desc, comment=comment, params=params)
+        if meas_offset:
+            self.params["meas_offset"] = meas_offset
+        if meas_scale:
+            self.params["meas_scale"] = meas_scale
 
     def rescale(self, pop1):
         """

--- a/c3/model.py
+++ b/c3/model.py
@@ -207,17 +207,18 @@ class Model:
             this_dev = device_lib[dev_type](**props)
             couplings.append(this_dev)
 
-        tasks = []
-        for name, props in cfg["Tasks"].items():
-            props.update({"name": name})
-            task_type = props.pop("c3type")
-            task = task_lib[task_type](**props)
-            tasks.append(task)
+        if "Tasks" in cfg:
+            tasks = []
+            for name, props in cfg["Tasks"].items():
+                props.update({"name": name})
+                task_type = props.pop("c3type")
+                task = task_lib[task_type](**props)
+                tasks.append(task)
+            self.set_tasks(tasks)
 
         if "use_dressed_basis" in cfg:
             self.dressed = cfg["use_dressed_basis"]
         self.set_components(subsystems, couplings)
-        self.set_tasks(tasks)
         self.__create_labels()
         self.__create_annihilators()
         self.__create_matrix_representations()

--- a/test/test_model.cfg
+++ b/test/test_model.cfg
@@ -121,4 +121,128 @@
       "hamiltonian_func" : "x_drive"
     }
   }
+  Tasks:
+  {
+    init_ground:
+    {
+      c3type: InitialiseGround
+      params:
+      {
+        init_temp:
+        {
+          value: 0.05
+          min_val: -0.001
+          max_val: 0.22
+          unit: K
+          symbol: \alpha
+        }
+      }
+    }
+    conf_matrix:
+    {
+      c3type: ConfusionMatrix
+      params:
+      {
+        confusion_row_Q1:
+        {
+          value:
+          [
+            0.97
+            0.039999999999999994
+            0.039999999999999994
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+        confusion_row_Q2:
+        {
+          value:
+          [
+            0.96
+            0.05
+            0.05
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+      }
+    }
+    meas_rescale:
+    {
+      c3type: MeasurementRescale
+      params:
+      {
+        meas_offset:
+        {
+          value:
+          [
+            0.97
+            0.039999999999999994
+            0.039999999999999994
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+        meas_scale:
+        {
+          value:
+          [
+            0.96
+            0.05
+            0.05
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+      }
+    }
+  }
 }

--- a/test/test_model_spam.cfg
+++ b/test/test_model_spam.cfg
@@ -121,4 +121,128 @@
       "hamiltonian_func" : "x_drive"
     }
   }
+  Tasks:
+  {
+    init_ground:
+    {
+      c3type: InitialiseGround
+      params:
+      {
+        init_temp:
+        {
+          value: 0.05
+          min_val: -0.001
+          max_val: 0.22
+          unit: K
+          symbol: \alpha
+        }
+      }
+    }
+    conf_matrix:
+    {
+      c3type: ConfusionMatrix
+      params:
+      {
+        confusion_row_Q1:
+        {
+          value:
+          [
+            0.97
+            0.039999999999999994
+            0.039999999999999994
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+        confusion_row_Q2:
+        {
+          value:
+          [
+            0.96
+            0.05
+            0.05
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+      }
+    }
+    meas_rescale:
+    {
+      c3type: MeasurementRescale
+      params:
+      {
+        meas_offset:
+        {
+          value:
+          [
+            0.97
+            0.039999999999999994
+            0.039999999999999994
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+        meas_scale:
+        {
+          value:
+          [
+            0.96
+            0.05
+            0.05
+          ]
+          min_val:
+          [
+            0.8
+            0.0
+            0.0
+          ]
+          max_val:
+          [
+            1.0
+            0.2
+            0.2
+          ]
+          unit: ""
+          symbol: \alpha
+        }
+      }
+    }
+  }
 }

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -34,7 +34,14 @@ def test_couplings() -> None:
     assert list(model.couplings.keys()) == ["Q1-Q2", "Q4-Q6", "d1", "d2"]
 
 
+@pytest.mark.unit
 def test_tasks() -> None:
+    """Task creation is tested separately in the absence of Von Neumann eqn
+    """
+    model = Model()
+    model.read_config("test/test_model_spam.cfg")
+    pmap = ParameterMap(model=model, generator=gen)
+    pmap.read_config("test/instructions.cfg")
     assert list(model.tasks.keys()) == ["init_ground", "conf_matrix", "meas_rescale"]
 
 

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -34,6 +34,10 @@ def test_couplings() -> None:
     assert list(model.couplings.keys()) == ["Q1-Q2", "Q4-Q6", "d1", "d2"]
 
 
+def test_tasks() -> None:
+    assert list(model.tasks.keys()) == ["init_ground", "conf_matrix", "meas_rescale"]
+
+
 @pytest.mark.unit
 def test_q6_freq() -> None:
     assert str(model.subsystems["Q6"].params["freq"]) == "4.600 GHz 2pi "


### PR DESCRIPTION
## What
When a model is written to or read from a configuration file, the tasks are formatted and parsed, too.

## Why
Fixes #18 

## How
Almost the same as it is done for the qubits and couplings in a model. There's a list of possible classes in `tasks.py:task_lib` and instances are created by passing the parsed dictionaries to the classes' constructors in the `params` argument. As far as I can see, adding that argument doesn't create any conflict with the normal usage of the constructors.