### PR TITLE
Bugfix in transmon class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This Changelog tracks all past changes to this project as well as details about 
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Upcoming Version
+
+### Details
+
+- `fixed` handling of anharmonicity in transmons with two levels #145
+
 ## Version `1.3` - 20 Jul 2021
 
 ### Summary

--- a/c3/libraries/chip.py
+++ b/c3/libraries/chip.py
@@ -408,7 +408,6 @@ class Transmon(PhysicalComponent):
     ):
         Hs = self.get_transformed_hamiltonians(transform)
         H_freq = Hs["freq"]
-        H_anhar = Hs["anhar"]
 
         if isinstance(signal, dict):
             sig = signal["values"]
@@ -420,7 +419,7 @@ class Transmon(PhysicalComponent):
 
         h = freq * H_freq
         if self.hilbert_dim > 2:
-            h += self.get_anhar() * H_anhar
+            h += self.get_anhar() * Hs["anhar"]
         return h
 
     def get_Lindbladian(self, dims):


### PR DESCRIPTION
## What
The `Transmon` class is using the anharmonic part of the Hamiltonian (`Hs["anhar"]`) which is, however, only generated if the levels are >2. A transmon with 2 levels throws an error. This fixes it.

## Why
Because it wasn't working

## How
Only use the parameter if levels are >2.

## Remarks

## Checklist

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hint
- [ ] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
