### PR TITLE
Set initial statevector with `qiskit` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This Changelog tracks all past changes to this project as well as details about 
 
 ### Details
 
+- `added` support for setting initial statevector using qiskit interface #171
 - `fixed` code quality and refactored parts of qiskit backend #170
 - `added` examples and documentation showing qiskit visualisations in optimal control workflows #169
 - `added` option to get and set c3 experiment object for qiskit simulations #169

--- a/c3/experiment.py
+++ b/c3/experiment.py
@@ -236,7 +236,7 @@ class Experiment:
     def __str__(self) -> str:
         return hjson.dumps(self.asdict(), default=hjson_encode)
 
-    def evaluate_legacy(self, sequences):
+    def evaluate_legacy(self, sequences, psi_init=None):
         """
         Compute the population values for a given sequence of operations.
 
@@ -252,9 +252,10 @@ class Experiment:
 
         """
         model = self.pmap.model
-        psi_init = model.tasks["init_ground"].initialise(
-            model.drift_ham, model.lindbladian
-        )
+        if psi_init is None:
+            psi_init = model.tasks["init_ground"].initialise(
+                model.drift_ham, model.lindbladian
+            )
         self.psi_init = psi_init
         populations = []
         for sequence in sequences:
@@ -266,7 +267,7 @@ class Experiment:
             populations.append(pops)
         return populations
 
-    def evaluate_qasm(self, sequences):
+    def evaluate_qasm(self, sequences, psi_init=None):
         """
         Compute the population values for a given sequence (in QASM format) of
         operations.
@@ -283,12 +284,13 @@ class Experiment:
 
         """
         model = self.pmap.model
-        if "init_ground" in model.tasks:
-            psi_init = model.tasks["init_ground"].initialise(
-                model.drift_ham, model.lindbladian
-            )
-        else:
-            psi_init = model.get_ground_state()
+        if psi_init is None:
+            if "init_ground" in model.tasks:
+                psi_init = model.tasks["init_ground"].initialise(
+                    model.drift_ham, model.lindbladian
+                )
+            else:
+                psi_init = model.get_ground_state()
         self.psi_init = psi_init
         populations = []
         for sequence in sequences:

--- a/c3/experiment.py
+++ b/c3/experiment.py
@@ -236,7 +236,7 @@ class Experiment:
     def __str__(self) -> str:
         return hjson.dumps(self.asdict(), default=hjson_encode)
 
-    def evaluate_legacy(self, sequences, psi_init=None):
+    def evaluate_legacy(self, sequences, psi_init: tf.Tensor = None):
         """
         Compute the population values for a given sequence of operations.
 
@@ -244,6 +244,9 @@ class Experiment:
         ----------
         sequences: str list
             A list of control pulses/gates to perform on the device.
+
+        psi_init: tf.Tensor
+            A tensor containing the initial statevector
 
         Returns
         -------
@@ -267,7 +270,7 @@ class Experiment:
             populations.append(pops)
         return populations
 
-    def evaluate_qasm(self, sequences, psi_init=None):
+    def evaluate_qasm(self, sequences, psi_init: tf.Tensor = None):
         """
         Compute the population values for a given sequence (in QASM format) of
         operations.
@@ -276,6 +279,9 @@ class Experiment:
         ----------
         sequences: dict list
             A list of control pulses/gates to perform on the device in QASM format.
+
+        psi_init: tf.Tensor
+            A tensor containing the initial statevector
 
         Returns
         -------

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -675,7 +675,7 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
             experiment.instructions
         )
 
-        pops = exp.evaluate([sanitized_instructions])
+        pops = exp.evaluate([sanitized_instructions], self._initial_statevector)
         pop1s, _ = exp.process(pops)
 
         # C3 stores labels in exp.pmap.model.state_labels

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -530,7 +530,12 @@ class C3QasmPerfectSimulator(C3QasmSimulator):
         perfect_gates = exp.get_perfect_gates(gate_keys)
 
         # initialise state
-        psi_init = get_init_ground_state(self._number_of_qubits, self._number_of_levels)
+        if self._initial_statevector is None:
+            psi_init = get_init_ground_state(
+                self._number_of_qubits, self._number_of_levels
+            )
+        else:
+            psi_init = self._initial_statevector
         psi_t = psi_init.numpy()
         pop_t = exp.populations(psi_t, False)
 

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -350,34 +350,15 @@ class C3QasmSimulator(Backend, ABC):
                 )
 
     def _validate_initial_statevector(self):
-        """Raise an error when experiment tries to set initial statevector
+        """Check initial statevector has correct dimensions
+        and is normalised
 
         Raises
         ------
         C3QiskitError
-            Error for statevector initialisation not implemented
+            If statevector is not correctly initialised
         """
-        if self._initial_statevector is not None:
-            raise C3QiskitError(
-                "Setting initial statevector is not implemented in this simulator"
-            )
-        else:
-            pass
-
-    def _initialize_statevector(self):
-        """Raise an error when experiment tries to set initial statevector
-
-        Raises
-        ------
-        C3QiskitError
-            Error for statevector initialisation not implemented
-        """
-        if self._initial_statevector is not None:
-            raise C3QiskitError(
-                "Setting initial statevector is not implemented in this simulator"
-            )
-        else:
-            pass
+        pass
 
     def _set_options(self, qobj_config=None, backend_options=None):
         """Qiskit stock method to Set the backend options for all experiments in a qobj"""
@@ -396,14 +377,6 @@ class C3QasmSimulator(Backend, ABC):
             self._initial_statevector = np.array(
                 qobj_config.initial_statevector, dtype=complex
             )
-        if self._initial_statevector is not None:
-            # Check the initial statevector is normalized
-            norm = np.linalg.norm(self._initial_statevector)
-            if round(norm, 12) != 1:
-                raise C3QiskitError(
-                    "initial statevector is not normalized: "
-                    + "norm {} != 1".format(norm)
-                )
 
 
 class C3QasmPerfectSimulator(C3QasmSimulator):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,6 +14,7 @@ from c3.generator.generator import Generator
 from c3.generator.devices import Crosstalk
 from c3.libraries.constants import Id, X, Y, Z
 from c3.c3objs import Quantity
+from c3.qiskit.c3_gates import RX90pGate, CR90Gate
 import pytest
 
 
@@ -55,19 +56,17 @@ def get_test_circuit() -> QuantumCircuit:
 
 
 @pytest.fixture()
-def get_bell_circuit() -> QuantumCircuit:
-    """fixture for Quantum Circuit to make Bell
-    State |11> + |00>
+def get_physics_circuit() -> QuantumCircuit:
+    """fixture for Quantum Circuit for physics simulation
 
     Returns
     -------
     QuantumCircuit
-        A circuit with a Hadamard, a C-X and 2 Measures
+        A circuit with a RX90p, and a CR90
     """
-    qc = QuantumCircuit(2, 2)
-    qc.h(0)
-    qc.cx(0, 1)
-    qc.measure([0, 1], [0, 1])
+    qc = QuantumCircuit(3)
+    qc.append(RX90pGate(), [0])
+    qc.append(CR90Gate(), [0, 1])
     return qc
 
 

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -147,14 +147,12 @@ def test_get_exception(get_bad_circuit, backend):  # noqa
 @pytest.mark.integration
 @pytest.mark.qiskit
 @pytest.mark.slow
-def test_qiskit_physics():
+def test_qiskit_physics(get_physics_circuit):
     """API test for qiskit physics simulation"""
     c3_qiskit = C3Provider()
     physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
     physics_backend.set_device_config("test/qiskit.cfg")
-    qc = QuantumCircuit(3)
-    qc.append(RX90pGate(), [0])
-    qc.append(CR90Gate(), [0, 1])
+    qc = get_physics_circuit
     qc.measure_all()
     job_sim = physics_backend.run(qc)
     expected_pops = np.array([0, 0, 0.5, 0, 0, 0, 0.5, 0])
@@ -278,25 +276,22 @@ def test_user_provided_c3_exp(backend, config_file):
         pytest.param("c3_qasm_physics_simulator", id="physics_sim"),
     ],
 )
-def test_experiment_not_initialised(backend):
+def test_experiment_not_initialised(backend, get_test_circuit):
     """Test for checking error is raised if c3 experiment object is not correctly initialised"""
     c3_qiskit = C3Provider()
     received_backend = c3_qiskit.get_backend(backend)
-    qc = QuantumCircuit(1, 1)
-    qc.x(0)
+    qc = get_test_circuit
     with pytest.raises(C3QiskitError):
         received_backend.run(qc)
 
 
 @pytest.mark.qiskit
 @pytest.mark.unit
-def test_initial_statevector():
+def test_initial_statevector(get_physics_circuit):
     c3_qiskit = C3Provider()
     physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
     physics_backend.set_device_config("test/qiskit.cfg")
-    qc = QuantumCircuit(3)
-    qc.append(RX90pGate(), [0])
-    qc.append(CR90Gate(), [0, 1])
+    qc = get_physics_circuit
     qc.measure_all()
     with pytest.raises(C3QiskitError):
         # incorrect dimension

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -288,6 +288,13 @@ def test_experiment_not_initialised(backend, get_test_circuit):
 @pytest.mark.qiskit
 @pytest.mark.unit
 def test_initial_statevector(get_physics_circuit):
+    """Check initial statevector is correctly validated
+
+    Parameters
+    ----------
+    get_physics_circuit : QuantumCircuit
+        Circuit fixture with RX90p and CR90 gates
+    """
     c3_qiskit = C3Provider()
     physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
     physics_backend.set_device_config("test/qiskit.cfg")

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -288,6 +288,8 @@ def test_experiment_not_initialised(backend):
         received_backend.run(qc)
 
 
+@pytest.mark.qiskit
+@pytest.mark.unit
 def test_initial_statevector():
     c3_qiskit = C3Provider()
     physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
@@ -303,8 +305,3 @@ def test_initial_statevector():
     with pytest.raises(C3QiskitError):
         # unnormalised
         physics_backend.run(qc, initial_statevector=[1, 1, 1, 1, 1, 1, 1, 1])
-
-    result = physics_backend.run(
-        qc, initial_statevector=[0, 1, 0, 0, 0, 0, 0, 0]
-    ).result()
-    print(result.get_counts())

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -286,3 +286,25 @@ def test_experiment_not_initialised(backend):
     qc.x(0)
     with pytest.raises(C3QiskitError):
         received_backend.run(qc)
+
+
+def test_initial_statevector():
+    c3_qiskit = C3Provider()
+    physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
+    physics_backend.set_device_config("test/qiskit.cfg")
+    qc = QuantumCircuit(3)
+    qc.append(RX90pGate(), [0])
+    qc.append(CR90Gate(), [0, 1])
+    qc.measure_all()
+    with pytest.raises(C3QiskitError):
+        # incorrect dimension
+        physics_backend.run(qc, initial_statevector=[0, 0, 0, 0, 0, 0, 1])
+
+    with pytest.raises(C3QiskitError):
+        # unnormalised
+        physics_backend.run(qc, initial_statevector=[1, 1, 1, 1, 1, 1, 1, 1])
+
+    result = physics_backend.run(
+        qc, initial_statevector=[0, 1, 0, 0, 0, 0, 0, 0]
+    ).result()
+    print(result.get_counts())


### PR DESCRIPTION
## What
Set the initial state when simulating the evolution with a quantum circuit 

## Why
-

## How
Supported interface:
```python
psi_init = [0, 1, 0, 0, 0, 0, 0, 0] # 3 qubits
backend.run(qc, initial_statevector = psi_init)
```

## Remarks
Add notes on possible known quirks/drawbacks of this solution. If this introduces an API-breaking change, please provide an explanation on why it is necessary to break API compatibility and how users should update their notebook/script workflows once this PR is merged.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
