### PR TITLE
Explicit setting and getting of the model parameters.

### DIFF
--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -37,7 +37,7 @@ class ParameterMap:
             components.update(generator.devices)
         self.__components = components
         self.update_model = False
-        self.set_parameters_scaled = self._set_parameters_scaled
+        self.set_parameters_scaled = self._set_parameters_scaled_ctrls
         self.__initialize_parameters()
 
     def __initialize_parameters(self) -> None:
@@ -347,12 +347,13 @@ class ParameterMap:
             values.append(par.get_opt_value())
         return values
 
-    def _set_parameters_scaled(
+    def _set_parameters_scaled_ctrls(
         self, values: Union[tf.constant, tf.Variable], opt_map=None
     ) -> None:
         """
         Set the values in the original instruction class. This fuction should only be
-        called by an optimizer. Are you an optimizer?
+        called by an optimizer. Are you an optimizer? This method only sets control
+        parameters and does not trigger a model update.
 
         Parameters
         ----------
@@ -384,7 +385,7 @@ class ParameterMap:
             List of parameter values. Matrix valued parameters need to be flattened.
 
         """
-        self._set_parameters_scaled(values)
+        self._set_parameters_scaled_ctrls(values)
         self.model.update_model()
 
     def get_key_from_scaled_index(self, idx, opt_map=None) -> str:
@@ -433,7 +434,7 @@ class ParameterMap:
         if update:
             self.set_parameters_scaled = self._set_parameters_scaled_model
         else:
-            self.set_parameters_scaled = self._set_parameters_scaled
+            self.set_parameters_scaled = self._set_parameters_scaled_ctrls
 
     def get_opt_map(self, opt_map=None) -> List[List[str]]:
         if opt_map is None:

--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -36,6 +36,8 @@ class ParameterMap:
         if generator:
             components.update(generator.devices)
         self.__components = components
+        self.update_model = False
+        self.set_parameters_scaled = self._set_parameters_scaled
         self.__initialize_parameters()
 
     def __initialize_parameters(self) -> None:
@@ -345,7 +347,7 @@ class ParameterMap:
             values.append(par.get_opt_value())
         return values
 
-    def set_parameters_scaled(
+    def _set_parameters_scaled(
         self, values: Union[tf.constant, tf.Variable], opt_map=None
     ) -> None:
         """
@@ -358,7 +360,6 @@ class ParameterMap:
             List of parameter values. Matrix valued parameters need to be flattened.
 
         """
-        model_updated = False
         val_indx = 0
         opt_map = self.get_opt_map(opt_map)
         for equiv_ids in opt_map:
@@ -366,12 +367,25 @@ class ParameterMap:
             par_len = self._pars[key].length
             for par_id in equiv_ids:
                 key = par_id
-                model_updated = True if key in self._par_ids_model else model_updated
                 par = self._pars[key]
                 par.set_opt_value(values[val_indx : val_indx + par_len])
             val_indx += par_len
-        if model_updated:
-            self.model.update_model()
+
+    def _set_parameters_scaled_model(
+        self, values: Union[tf.constant, tf.Variable], opt_map=None
+    ) -> None:
+        """
+        Set the values in the original instruction class. This fuction should only be
+        called by an optimizer. Are you an optimizer? Also update the model.
+
+        Parameters
+        ----------
+        values: list
+            List of parameter values. Matrix valued parameters need to be flattened.
+
+        """
+        self._set_parameters_scaled(values)
+        self.model.update_model()
 
     def get_key_from_scaled_index(self, idx, opt_map=None) -> str:
         """
@@ -400,6 +414,7 @@ class ParameterMap:
         Set the opt_map, i.e. which parameters will be optimized.
         """
         opt_map = self.get_opt_map(opt_map)
+        update_model = False
         for equiv_ids in opt_map:
             for pid in equiv_ids:
                 key = pid
@@ -408,8 +423,17 @@ class ParameterMap:
                     raise Exception(
                         f"C3:ERROR:Parameter {key} not defined in {par_strings}"
                     )
+                update_model = key in self._par_ids_model or update_model
+        self.set_update_model(update_model)
         self.check_limits(opt_map)
         self.opt_map = opt_map
+
+    def set_update_model(self, update: bool) -> None:
+        self.update_model = update
+        if update:
+            self.set_parameters_scaled = self._set_parameters_scaled_model
+        else:
+            self.set_parameters_scaled = self._set_parameters_scaled
 
     def get_opt_map(self, opt_map=None) -> List[List[str]]:
         if opt_map is None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -165,3 +165,11 @@ def test_model_update_by_parametermap() -> None:
 
     assert hdrift_a[3, 3] - hdrift_a[0, 0] == freq_q1 * 0.9995 * 2 * np.pi
     assert hdrift_b[3, 3] - hdrift_b[0, 0] == freq_q1 * 1.0005 * 2 * np.pi
+
+
+@pytest.mark.unit
+def test_model_recompute() -> None:
+    """Test whether setting a model parameter triggers recompute."""
+    assert not pmap.update_model
+    pmap.set_opt_map([[("Q1-Q2", "strength")]])
+    assert pmap.update_model


### PR DESCRIPTION
## What
Keep track of when optimizing model parameters.

## Why
closes #185 

## How
Instead of checking for model parameters each time when setting new parameters, we now check when the `opt_map` is set.

## Remark
We could be more clever by explicitly tracking what parameters require which re-computation. 

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
