### PR TITLE
Check how to find init state

### DIFF
--- a/c3/experiment.py
+++ b/c3/experiment.py
@@ -288,19 +288,11 @@ class Experiment:
 
         """
         model = self.pmap.model
-        if psi_init is None:
-            if "init_ground" in model.tasks:
-                self.psi_init = model.tasks["init_ground"].initialise(
-                    model.drift_ham, model.lindbladian
-                )
-            else:
-                self.psi_init = model.get_ground_state()
-        else:
-            self.psi_init = psi_init
-
+        if not psi_init:
+            psi_init = model.get_init_state()
         populations = []
         for sequence in sequences:
-            psi_t = copy.deepcopy(self.psi_init)
+            psi_t = copy.deepcopy(psi_init)
             for gate in sequence:
                 psi_t = tf.matmul(self.propagators[gate], psi_t)
 
@@ -329,12 +321,7 @@ class Experiment:
         """
         model = self.pmap.model
         if psi_init is None:
-            if "init_ground" in model.tasks:
-                psi_init = model.tasks["init_ground"].initialise(
-                    model.drift_ham, model.lindbladian
-                )
-            else:
-                psi_init = model.get_ground_state()
+            psi_init = model.get_init_state()
         self.psi_init = psi_init
         populations = []
         for sequence in sequences:

--- a/c3/experiment.py
+++ b/c3/experiment.py
@@ -289,10 +289,15 @@ class Experiment:
         """
         model = self.pmap.model
         if psi_init is None:
-            psi_init = model.tasks["init_ground"].initialise(
-                model.drift_ham, model.lindbladian
-            )
-        self.psi_init = psi_init
+            if "init_ground" in model.tasks:
+                self.psi_init = model.tasks["init_ground"].initialise(
+                    model.drift_ham, model.lindbladian
+                )
+            else:
+                self.psi_init = model.get_ground_state()
+        else:
+            self.psi_init = psi_init
+
         populations = []
         for sequence in sequences:
             psi_t = copy.deepcopy(self.psi_init)

--- a/c3/model.py
+++ b/c3/model.py
@@ -64,6 +64,16 @@ class Model:
         gs[0][0] = 1
         return tf.transpose(tf.constant(gs, dtype=tf.complex128))
 
+    def get_init_state(self) -> tf.Tensor:
+        """Get an initial state. If a task to compute a thermal state is set, return that."""
+        if "init_ground" in self.tasks:
+            psi_init = self.tasks["init_ground"].initialise(
+                self.drift_ham, self.lindbladian
+            )
+        else:
+            psi_init = self.get_ground_state()
+        return psi_init
+
     def __check_drive_connect(self, comp):
         for connect in comp.connected:
             try:
@@ -278,7 +288,7 @@ class Model:
         self.dressed = dressed
         self.update_model()
 
-    def set_lindbladian(self, lindbladian):
+    def set_lindbladian(self, lindbladian: bool) -> None:
         """
         Set whether to include open system dynamics.
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -179,10 +179,10 @@ def test_model_recompute() -> None:
 def test_model_thermal_state() -> None:
     """Test computation of initial state"""
     model.set_lindbladian(True)
-    np.testing.assert_almost_equal(model.get_init_state()[0], 0.9871523, decimal=7)
+    np.testing.assert_almost_equal(model.get_init_state()[0], 0.9871, decimal=4)
 
 
 @pytest.mark.unit
 def test_model_init_state() -> None:
     """Test computation of initial state"""
-    np.testing.assert_almost_equal(model.get_ground_state()[0], 1, decimal=7)
+    np.testing.assert_almost_equal(model.get_ground_state()[0], 1, decimal=4)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -173,3 +173,16 @@ def test_model_recompute() -> None:
     assert not pmap.update_model
     pmap.set_opt_map([[("Q1-Q2", "strength")]])
     assert pmap.update_model
+
+
+@pytest.mark.unit
+def test_model_thermal_state() -> None:
+    """Test computation of initial state"""
+    model.set_lindbladian(True)
+    np.testing.assert_almost_equal(model.get_init_state()[0], 0.9871523, decimal=7)
+
+
+@pytest.mark.unit
+def test_model_init_state() -> None:
+    """Test computation of initial state"""
+    np.testing.assert_almost_equal(model.get_ground_state()[0], 1, decimal=7)


### PR DESCRIPTION
## What
Find an appropriate initial state for sequence evaluation if none is explicitly provided.

## Why
closes #189 

## How
Check for the thermal state initialisation task before attempting to use it. If it's not present, check for a model method.

## Remarks
If the model has no method to provide the ground state this raises an error. We could discuss whether we require a model to provide the method or what custom error to raise instead.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
