### PR TITLE
Set pulse parameters through Qiskit

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install c3 package
       run: |
         python -m pip install --upgrade pip
-        pip install pytest qiskit==0.25.0
+        pip install pytest qiskit
         pip install .
     - name: Test with pytest
       run: |

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -684,6 +684,14 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         start = time.time()
 
         exp = self._setup_c3_experiment(experiment)
+        if self.options.get("params"):
+            params = self.options.get("params")
+            opt_map = self.options.get("opt_map")
+            if not opt_map:
+                raise KeyError(
+                    "Missing opt_map in options to run(), required for updating parameters"
+                )
+            exp.pmap.set_parameters(params, opt_map)
         exp.compute_propagators()
 
         sanitized_instructions, instructions_list = self.sanitize_instructions(

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -254,19 +254,37 @@ class C3QasmSimulator(Backend, ABC):
 
         Notes
         -----
-        backend_options: Is a dict of options for the backend. It may contain
-                * "initial_statevector": vector_like
+        backend_options: Is a dict of options for the backend. It may contain::
 
-        The "initial_statevector" option specifies a custom initial statevector
+            "initial_statevector": vector_like
+
+        The ``initial_statevector`` option specifies a custom initial statevector
         for the simulator to be used instead of the all zero state. This size of
         this vector must be correct for the number of qubits in all experiments
-        in the qobj.
-
-        Example::
+        in the qobj. Example::
 
             backend_options = {
                 "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
             }
+
+        ::
+
+            "params": list
+
+        List of parameter values. Can be nested, if a parameter is matrix valued. ::
+
+            "opt_map": list
+
+        Corresponding identifiers for the parameter values. ::
+
+            "shots": int
+
+        Total number of measurement shots. ::
+
+            "memory": bool
+
+        Whether individual measurement readout is stored.
+
         """
 
         if isinstance(qobj, (QuantumCircuit, list)):

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -388,11 +388,16 @@ class C3QasmSimulator(Backend, ABC):
             )
 
     def _set_options(self, qobj_config=None, backend_options=None):
-        """Qiskit stock method to Set the backend options for all experiments in a qobj"""
-        # Reset default options
+        """Set the backend options for all experiments in a qobj"""
+        # set runtime options
+        for field in backend_options:
+            if not hasattr(self._options, field):
+                raise AttributeError(
+                    "Options field %s is not valid for this backend" % field
+                )
+        self._options.update_options(**backend_options)
+
         self._initial_statevector = self.options.get("initial_statevector")
-        if "backend_options" in backend_options and backend_options["backend_options"]:
-            backend_options = backend_options["backend_options"]
 
         # Check for custom initial statevector in backend_options first,
         # then config second

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -615,8 +615,6 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         "gates": [],
     }
 
-    DEFAULT_OPTIONS = {"initial_statevector": None, "shots": 1024, "memory": False}
-
     def __init__(self, configuration=None, provider=None, **fields):
         super().__init__(
             configuration=(

--- a/c3/qiskit/c3_backend.py
+++ b/c3/qiskit/c3_backend.py
@@ -22,6 +22,7 @@ from c3.experiment import Experiment
 from .c3_exceptions import C3QiskitError
 from .c3_job import C3Job
 from .c3_backend_utils import get_init_ground_state, get_sequence, flip_labels
+from .c3_options import C3Options
 
 from typing import Any, Dict, List, Tuple
 from abc import ABC, abstractclassmethod, abstractmethod
@@ -49,7 +50,7 @@ class C3QasmSimulator(Backend, ABC):
     """
 
     @abstractclassmethod
-    def _default_options(cls) -> None:
+    def _default_options(cls) -> C3Options:
         raise NotImplementedError("This must be implemented in the derived class")
 
     def set_device_config(self, config_file: str) -> None:
@@ -635,8 +636,15 @@ class C3QasmPhysicsSimulator(C3QasmSimulator):
         self.c3_exp = Experiment()
 
     @classmethod
-    def _default_options(cls) -> Options:
-        return Options(shots=1024, memory=False, initial_statevector=None)
+    def _default_options(cls) -> C3Options:
+        DEFAULT_OPTIONS = {
+            "params": None,
+            "opt_map": None,
+            "shots": 1024,
+            "memory": False,
+            "initial_statevector": None,
+        }
+        return C3Options(**DEFAULT_OPTIONS)
 
     def run_experiment(self, experiment: QasmQobjExperiment) -> Dict[str, Any]:
         """Run an experiment (circuit) and return a single experiment result

--- a/c3/qiskit/c3_options.py
+++ b/c3/qiskit/c3_options.py
@@ -1,0 +1,36 @@
+"""Module to implement a C3Options class derived from the native
+qiskit Options class"""
+
+from typing import Any, Dict
+from qiskit.providers import Options
+
+
+class C3Options(Options):
+    """A derived class of the base Options class in Qiskit.
+
+    It only provides an additional to_dict() method to obtain
+    all the options as a single dictionary
+
+    Parameters
+    ----------
+    Options : qiskit.providers.Options
+        Base class for Options. The get() and update_options() are
+        used from this base class
+    """
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dict representation of the options
+
+        Returns
+        -------
+        Dict[str, Any]
+            The Options in the form of a dictionary
+        """
+        out_dict = {
+            "params": self.params,
+            "opt_map": self.opt_map,
+            "shots": self.shots,
+            "memory": self.memory,
+            "initial_statevector": self.initial_statevector,
+        }
+        return out_dict

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -4,6 +4,7 @@
 import json
 from c3.libraries.constants import GATES
 from c3.experiment import Experiment
+from c3.c3objs import Quantity as Qty
 from c3.qiskit import C3Provider
 from c3.qiskit.c3_exceptions import C3QiskitError
 from c3.qiskit.c3_gates import (
@@ -158,6 +159,18 @@ def test_qiskit_physics(get_physics_circuit):
     expected_pops = np.array([0, 0, 0.5, 0, 0, 0, 0.5, 0])
     received_pops = np.array(list(job_sim.result().data()["state_pops"].values()))
     np.testing.assert_allclose(received_pops, desired=expected_pops, atol=1e-1)
+
+    # Test that runtime options are correctly assigned
+    opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
+    param = [
+        Qty(value=0.5, min_val=0.2, max_val=0.6, unit="V"),
+    ]
+    _ = physics_backend.run(qc, params=param, opt_map=opt_map)
+    physics_backend.c3_exp.pmap.set_opt_map(opt_map)
+    assert (
+        physics_backend.c3_exp.pmap.get_parameter_dict()["rx90p[0]-d1-gaussian-amp"]
+        == param[0]
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Allow users to update pulse-parameters at runtime through the qiskit interface 

## Why
This increases qiskit support for pulse level control of c3 simulator, and better mimics (on the digital twin) how hardware calibration is performed.

## How
Users can provide parameters as options to the `backend.run()` as below:

```python
# Test that runtime options are correctly assigned
opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
param = [
        Qty(value=0.5, min_val=0.2, max_val=0.6, unit="V"),
    ]
backend.run(qc, params=param, opt_map=opt_map)
```

## Remarks
Add notes on possible known quirks/drawbacks of this solution. If this introduces an API-breaking change, please provide an explanation on why it is necessary to break API compatibility and how users should update their notebook/script workflows once this PR is merged.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
