### PR TITLE
Update Parameters through Gate in Qiskit interface

### DIFF
--- a/c3/qiskit/c3_gates.py
+++ b/c3/qiskit/c3_gates.py
@@ -117,10 +117,13 @@ class CR90Gate(UnitaryGate):
 
 
 class SetParamsGate(Gate):
-    """Gate for setting parameter values through qiskit interface
+    """Gate for setting parameter values through qiskit interface. This gate is only
+    processed when it is the last gate in the circuit, otherwise it throws a KeyError.
+    The qubit target for the gate can be any valid qubit in the circuit, this argument
+    is currently ignored and not processed by the backend
 
-    These parameters should be supplied as a list with the first item
-    a list of Quantity objects converted to Dict and the second item an
+    These parameters should be supplied as a list with the first item a list of
+    Quantity objects converted to a Dict of Python primitives and the second item an
     opt_map with the proper list nesting. For example: ::
 
         amp = Qty(value=0.8, min_val=0.2, max_val=1, unit="V")

--- a/c3/qiskit/c3_gates.py
+++ b/c3/qiskit/c3_gates.py
@@ -1,7 +1,8 @@
 """Library for interoperability of c3 gates with qiskit
 """
-from typing import Optional
+from typing import Iterable, List, Optional
 from qiskit.extensions import UnitaryGate
+from qiskit.circuit import Gate
 from qiskit.circuit.library import RXGate, RYGate, RZGate, CRXGate
 from c3.libraries.constants import GATES
 import numpy as np
@@ -113,3 +114,35 @@ class CR90Gate(UnitaryGate):
         warnings.warn("This is not equivalent to the RZX(pi/2) gate in qiskit")
         super().__init__(data=GATES["cr90"], label=label)
         self.name = "cr90"
+
+
+class SetParamsGate(Gate):
+    """Gate for setting parameter values through qiskit interface
+
+    These parameters should be supplied as a list with the first item
+    a list of Quantity objects converted to Dict and the second item an
+    opt_map with the proper list nesting. For example: ::
+
+        amp = Qty(value=0.8, min_val=0.2, max_val=1, unit="V")
+        opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
+        param_gate = SetParamsGate(params=[[amp.asdict()], opt_map])
+    """
+
+    def __init__(self, params: List) -> None:
+        name = "param_update"
+        num_qubits = 1
+        label = None
+        super().__init__(name, num_qubits, params, label)
+
+    def validate_parameter(self, parameter: Iterable) -> Iterable:
+        """Override the default validation in Gate to allow arbitrary lists
+        ----------
+        parameter : Iterable
+            The waveform as a nested list
+        Returns
+        -------
+        Iterable
+            The same waveform
+        """
+        # TODO implement sanitation/validation as required
+        return parameter

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -20,6 +20,7 @@ from c3.qiskit.c3_gates import (
     CRXpGate,
     CRGate,
     CR90Gate,
+    SetParamsGate,
 )
 from qiskit.circuit.library import RXGate, RYGate, RZGate, CRXGate
 from qiskit.extensions import UnitaryGate
@@ -160,6 +161,7 @@ def test_qiskit_physics(get_physics_circuit):
     received_pops = np.array(list(job_sim.result().data()["state_pops"].values()))
     np.testing.assert_allclose(received_pops, desired=expected_pops, atol=1e-1)
 
+
 @pytest.mark.unit
 @pytest.mark.qiskit
 @pytest.mark.slow
@@ -168,7 +170,7 @@ def test_qiskit_parameter_update(get_physics_circuit):
     c3_qiskit = C3Provider()
     physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
     physics_backend.set_device_config("test/qiskit.cfg")
-    qc = get_physics_circuit
+    qc = get_physics_circuit  # TODO use a smaller circuit
 
     # Test that runtime options are correctly assigned
     opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
@@ -177,8 +179,25 @@ def test_qiskit_parameter_update(get_physics_circuit):
     ]
     _ = physics_backend.run(qc, params=param, opt_map=opt_map)
     physics_backend.c3_exp.pmap.set_opt_map(opt_map)
-    np.testing.assert_allclose(physics_backend.c3_exp.pmap.get_parameter_dict()["rx90p[0]-d1-gaussian-amp"].numpy(),
-        param[0].numpy())
+    np.testing.assert_allclose(
+        physics_backend.c3_exp.pmap.get_parameter_dict()[
+            "rx90p[0]-d1-gaussian-amp"
+        ].numpy(),
+        param[0].numpy(),
+    )
+
+    # Test that custom gate for setting parameters works
+    amp = Qty(value=0.8, min_val=0.2, max_val=1, unit="V")
+    opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
+    param_gate = SetParamsGate(params=[[amp.asdict()], opt_map])
+    qc.append(param_gate, [0])
+    _ = physics_backend.run(qc)
+    np.testing.assert_allclose(
+        physics_backend.c3_exp.pmap.get_parameter_dict()[
+            "rx90p[0]-d1-gaussian-amp"
+        ].numpy(),
+        amp.numpy(),
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -160,6 +160,16 @@ def test_qiskit_physics(get_physics_circuit):
     received_pops = np.array(list(job_sim.result().data()["state_pops"].values()))
     np.testing.assert_allclose(received_pops, desired=expected_pops, atol=1e-1)
 
+@pytest.mark.unit
+@pytest.mark.qiskit
+@pytest.mark.slow
+def test_qiskit_parameter_update(get_physics_circuit):
+    """Test for checking parameters are updated by the gate & options interface"""
+    c3_qiskit = C3Provider()
+    physics_backend = c3_qiskit.get_backend("c3_qasm_physics_simulator")
+    physics_backend.set_device_config("test/qiskit.cfg")
+    qc = get_physics_circuit
+
     # Test that runtime options are correctly assigned
     opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
     param = [
@@ -167,10 +177,8 @@ def test_qiskit_physics(get_physics_circuit):
     ]
     _ = physics_backend.run(qc, params=param, opt_map=opt_map)
     physics_backend.c3_exp.pmap.set_opt_map(opt_map)
-    assert (
-        physics_backend.c3_exp.pmap.get_parameter_dict()["rx90p[0]-d1-gaussian-amp"]
-        == param[0]
-    )
+    np.testing.assert_allclose(physics_backend.c3_exp.pmap.get_parameter_dict()["rx90p[0]-d1-gaussian-amp"].numpy(),
+        param[0].numpy())
 
 
 @pytest.mark.parametrize(

--- a/test/test_qiskit.py
+++ b/test/test_qiskit.py
@@ -199,6 +199,11 @@ def test_qiskit_parameter_update(get_physics_circuit):
         amp.numpy(),
     )
 
+    # Test that SetParamsGate not at the end raises an error
+    qc.append(RX90pGate(), [0])
+    with pytest.raises(KeyError):
+        _ = physics_backend.run(qc)
+
 
 @pytest.mark.parametrize(
     ["backend", "config_file"],


### PR DESCRIPTION
## What
Allow updating parameters of the underlying experiment object through custom qiskit gates, as below:

```python
amp = Qty(value=0.8, min_val=0.2, max_val=1, unit="V")
opt_map = [[["rx90p[0]", "d1", "gaussian", "amp"]]]
param_gate = SetParamsGate(params=[[amp.asdict()], opt_map])
qc.append(param_gate, [0])
```

## Why
Closes #200 

## How
- Added a new `SetParamsGate` class in the `c3.qiskit.c3_gates` module
- Update `run_experiment` to process this gate

## Remarks
- `SetParamsGate` should be the last gate in the circuit, otherwise it raises a `KeyError`
- The `params` argument should be supplied as a list  with the first item a list of Quantity objects converted to a Dict of Python primitives and the second item an opt_map with the proper list nesting
- The qubit target for the gate can be any valid qubit in the circuit, this argument is currently ignored and not processed by the backend
- runtime options for parameter update override gate-based updates

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
