### PR TITLE
Return dynamics's generators from Model

### DIFF
--- a/c3/experiment.py
+++ b/c3/experiment.py
@@ -503,7 +503,18 @@ class Experiment:
             )
             U = result["U"]
             dUs = result["dUs"]
-            self.ts = result["ts"]
+            signal = generator.generate_signals(instr)
+            ts_list = [sig["ts"][1:] for sig in signal.values()]
+            ts = tf.constant(tf.math.reduce_mean(ts_list, axis=0))
+            if not np.all(
+                tf.math.reduce_variance(ts_list, axis=0) < 1e-5 * (ts[1] - ts[0])
+            ):
+                raise Exception("C3Error:Something with the times happend.")
+            if not np.all(
+                tf.math.reduce_variance(ts[1:] - ts[:-1]) < 1e-5 * (ts[1] - ts[0])  # type: ignore
+            ):
+                raise Exception("C3Error:Something with the times happend.")
+            self.ts = ts
             if model.use_FR:
                 # TODO change LO freq to at the level of a line
                 freqs = {}

--- a/c3/libraries/propagation.py
+++ b/c3/libraries/propagation.py
@@ -380,20 +380,18 @@ def tf_batch_propagate(dyn_gens, batch_size):
     Propagate signal in batches
     Parameters
     ----------
-    hamiltonian: tf.tensor
-        Drift Hamiltonian
-    hks: Union[tf.tensor, List[tf.tensor]]
-        List of control hamiltonians
-    signals: Union[tf.tensor, List[tf.tensor]]
-        List of control signals, one per control hamiltonian
-    dt: float
-        Length of one time slice
+    dyn_gens: tf.tensor
+        i) -1j * Hamiltonian(t) * dt
+        or
+        ii) -1j * Liouville superoperator * dt
     batch_size: int
         Number of elements in one batch
 
     Returns
     -------
-
+    List of partial propagators
+    i) as operators
+    ii) as superoperators
     """
 
     batches = int(tf.math.ceil(dyn_gens.shape[0] / batch_size))
@@ -408,7 +406,7 @@ def tf_batch_propagate(dyn_gens, batch_size):
     dUs_array = tf.TensorArray(tf.complex128, size=batches, infer_shape=False)
     for i in range(batches):
         x = batch_array.read(i)
-        result = tf.linalg.expm(x)
+        result = tf.linalg.expm(tf.cast(x, dtype=tf.complex128))
         dUs_array = dUs_array.write(i, result)
     return dUs_array.concat()
 

--- a/c3/model.py
+++ b/c3/model.py
@@ -414,7 +414,14 @@ class Model:
         ts = []
         ts_list = [sig["ts"][1:] for sig in signal.values()]
         ts = tf.constant(tf.math.reduce_mean(ts_list, axis=0))
-
+        if not np.all(
+            tf.math.reduce_variance(ts_list, axis=0) < 1e-5 * (ts[1] - ts[0])
+        ):
+            raise Exception("C3Error:Something with the times happend.")
+        if not np.all(
+            tf.math.reduce_variance(ts[1:] - ts[:-1]) < 1e-5 * (ts[1] - ts[0])  # type: ignore
+        ):
+            raise Exception("C3Error:Something with the times happend.")
         dt = tf.cast(ts[1] - ts[0], dtype=tf.complex128)
 
         return dyn_gens * dt


### PR DESCRIPTION
## What
Ideally reinserts lindbladian evolution

## Why
Linbladian evolution was in the code but not accessible.
Reduces code complexity and nested ifs.
Closes Issue  #215

## How
A new function in the Model takes care of returning Hamiltonians or Liouvillian superoperators according to model.lindbladian.
In this way propagation.pwc() basically just needs to do the exponentiation.

## Remarks
Checks on signals (e. g. passing times) are supposed to be moved to the Generator and might be faulty now.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
