### PR TITLE
Truncating large parameters

### DIFF
--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -450,7 +450,9 @@ class ParameterMap:
         return opt_map
 
     def str_parameters(
-        self, opt_map: Union[List[List[Tuple[str]]], List[List[str]]] = None
+        self,
+        opt_map: Union[List[List[Tuple[str]]], List[List[str]]] = None,
+        human=False,
     ) -> str:
         """
         Return a multi-line human-readable string of the optmization parameter names and
@@ -472,7 +474,10 @@ class ParameterMap:
             par_id = equiv_ids[0]
             key = par_id
             par = self._pars[key]
-            ret.append(f"{key:38}: {par}\n")
+            if human and par.length > 4:  # Don't print large num of values
+                ret.append(f"{key:38}: <{par.length} values>\n")
+            else:
+                ret.append(f"{key:38}: {par}\n")
             if len(equiv_ids) > 1:
                 for eid in equiv_ids[1:]:
                     ret.append(eid)
@@ -485,4 +490,4 @@ class ParameterMap:
         Print current parameters to stdout.
         """
         opt_map = self.get_opt_map(opt_map)
-        print(self.str_parameters(opt_map))
+        print(self.str_parameters(opt_map, human=True))


### PR DESCRIPTION
## What
Truncate large vector or matrix valued parameters in human output.

## Why
Closes #224 

## How
Introduce a `human` parameter to the `str` method, truncate when it's set and a parameter has more than 4 values.

## Remarks 
The number when to truncate is negotiable, input welcome.

New look:
```
Q1-freq                               : 5.000 GHz 2pi 
Q2-freq                               : 5.600 GHz 2pi 
Q1-anhar                              : -150.000 MHz 2pi 
Q2-anhar                              : -150.000 MHz 2pi 
Q1-Q2-strength                        : 50.000 MHz 2pi 
cr90-d1-pwc-quadrature                : <100 values>
cr90-d1-pwc-inphase                   : <100 values>
```

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [ ] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
