### PR TITLE
Fix Instructions ideal gate assignment in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This Changelog tracks all past changes to this project as well as details about 
 - `added` proper physics simulation of circuits using qiskit interface #165
 - `added` coupling element which depends on frequency of connected qubits #211
 - `added` model subclass with an arbitrary specified basis change for simulations #220
+- `fixed` bug in Instruction where ideal gate's weren't properly set #229
 
 ## Version `1.4` - 23 Dec 2021
 

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -89,6 +89,7 @@ class Instruction:
 
     def set_name(self, name):
         self.name = name
+        self.set_ideal(None)  # sets from name
 
     def set_ideal(self, ideal):
         if ideal is not None:
@@ -311,11 +312,10 @@ class Instruction:
             t_start, t_end = self.get_timings(chan, comp_name)
             ts_off = ts - t_start
             if isinstance(comp, Envelope):
-
                 amp_re = comp.params["amp"].get_value()
                 amp = tf.complex(amp_re, tf.zeros_like(amp_re))
 
-                amp_tot_sq += amp**2
+                amp_tot_sq += amp ** 2
 
                 xy_angle = comp.params["xy_angle"].get_value()
                 freq_offset = comp.params["freq_offset"].get_value()
@@ -324,7 +324,7 @@ class Instruction:
                 env = tf.cast(env, tf.complex128)
 
                 signal += (
-                    amp * env * tf.math.exp(tf.complex(tf.zeros_like(phase), phase))
+                        amp * env * tf.math.exp(tf.complex(tf.zeros_like(phase), phase))
                 )
 
         norm = tf.sqrt(tf.cast(amp_tot_sq, tf.float64))

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -19,12 +19,14 @@ class Instruction:
 
     Parameters
     ----------
+    ideal: np.ndarray
+        Ideal gate that the instruction should emulate.
+    channels : list
+        List of channel names (strings).
     t_start : np.float64
         Start of the signal.
     t_end : np.float64
         End of the signal.
-    channels : list
-        List of channel names (strings)
 
 
     Attributes
@@ -52,7 +54,6 @@ class Instruction:
         channels: List[str] = [],
         t_start: float = 0.0,
         t_end: float = 0.0,
-        # fixed_t_end: bool = True,
     ):
         self.set_name(name)
         self.set_ideal(ideal)

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -55,6 +55,7 @@ class Instruction:
         # fixed_t_end: bool = True,
     ):
         self.set_name(name)
+        self.set_ideal(ideal)
         self.targets = targets
         self.params: dict = {}
         if isinstance(params, dict):
@@ -85,9 +86,8 @@ class Instruction:
             asdict["ideal"] = self.ideal
         return asdict
 
-    def set_name(self, name, ideal=None):
+    def set_name(self, name):
         self.name = name
-        self.set_ideal(ideal)
 
     def set_ideal(self, ideal):
         if ideal is not None:

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -315,7 +315,7 @@ class Instruction:
                 amp_re = comp.params["amp"].get_value()
                 amp = tf.complex(amp_re, tf.zeros_like(amp_re))
 
-                amp_tot_sq += amp ** 2
+                amp_tot_sq += amp**2
 
                 xy_angle = comp.params["xy_angle"].get_value()
                 freq_offset = comp.params["freq_offset"].get_value()
@@ -324,7 +324,7 @@ class Instruction:
                 env = tf.cast(env, tf.complex128)
 
                 signal += (
-                        amp * env * tf.math.exp(tf.complex(tf.zeros_like(phase), phase))
+                    amp * env * tf.math.exp(tf.complex(tf.zeros_like(phase), phase))
                 )
 
         norm = tf.sqrt(tf.cast(amp_tot_sq, tf.float64))

--- a/test/test_fidelities.py
+++ b/test/test_fidelities.py
@@ -163,23 +163,3 @@ def test_set_states() -> None:
         n_eval=136,
     )
     almost_equal(goal, 0)
-
-
-@pytest.mark.unit
-def test_correct_ideal_assignment() -> None:
-    custom_gate = np.array([[1, 0, 0, 0],
-                            [0, 1, 0, 0],
-                            [0, 0, 0, 1],
-                            [0, 0, 1, 0]], dtype=np.complex)
-    propagators = {"custom": custom_gate}
-    instructions = {"custom": Instruction("custom", ideal=custom_gate)}
-    psi_0 = np.array([[1], [0], [0], [0]])
-    goal = state_transfer_infid_set(
-        propagators=propagators,
-        instructions=instructions,
-        index=[0, 1],
-        dims=[2, 2],
-        psi_0=psi_0,
-        n_eval=136,
-    )
-    almost_equal(goal, 0)

--- a/test/test_fidelities.py
+++ b/test/test_fidelities.py
@@ -11,7 +11,6 @@ from c3.libraries.fidelities import (
 )
 from c3.libraries.constants import GATES
 
-
 X = GATES["rxp"]
 Y = GATES["ryp"]
 Id = GATES["id"]
@@ -160,6 +159,26 @@ def test_set_states() -> None:
         instructions=instructions,
         index=[0],
         dims=[2],
+        psi_0=psi_0,
+        n_eval=136,
+    )
+    almost_equal(goal, 0)
+
+
+@pytest.mark.unit
+def test_correct_ideal_assignment() -> None:
+    custom_gate = np.array([[1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 1],
+                            [0, 0, 1, 0]], dtype=np.complex)
+    propagators = {"custom": custom_gate}
+    instructions = {"custom": Instruction("custom", ideal=custom_gate)}
+    psi_0 = np.array([[1], [0], [0], [0]])
+    goal = state_transfer_infid_set(
+        propagators=propagators,
+        instructions=instructions,
+        index=[0, 1],
+        dims=[2, 2],
         psi_0=psi_0,
         n_eval=136,
     )

--- a/test/test_instruction.py
+++ b/test/test_instruction.py
@@ -2,7 +2,9 @@ import copy
 import pickle
 
 import hjson
+from numpy.testing import assert_array_almost_equal as almost_equal
 
+from c3.libraries.fidelities import state_transfer_infid_set
 from c3.signal.gates import Instruction
 
 from c3.c3objs import Quantity, hjson_decode, hjson_encode
@@ -187,3 +189,23 @@ def test_set_name_ideal():
     assert (instr.ideal == GATES["ry90p"]).all()
     instr.set_name("crzp")
     assert (instr.ideal == GATES["crzp"]).all()
+
+
+@pytest.mark.unit
+def test_correct_ideal_assignment() -> None:
+    custom_gate = np.array([[1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 1],
+                            [0, 0, 1, 0]], dtype=np.complex)
+    propagators = {"custom": custom_gate}
+    instructions = {"custom": Instruction("custom", ideal=custom_gate)}
+    psi_0 = np.array([[1], [0], [0], [0]])
+    goal = state_transfer_infid_set(
+        propagators=propagators,
+        instructions=instructions,
+        index=[0, 1],
+        dims=[2, 2],
+        psi_0=psi_0,
+        n_eval=136,
+    )
+    almost_equal(goal, 0)


### PR DESCRIPTION
## What
Makes the `Instruction` class properly assign ideal gate inside constructor. Also fixes the `two_qubits_entangling_gate.ipynb` example notebook.

## Why
Closes #229 

## How
Added `self.set_ideal(ideal)` to `Instructions` constructor.

## Remarks
None

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - A new test was created, manually made sure that it gives the required output on a simple test case and that it does not break some existing code.
- [x] Formatting & Linting - `black` has been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [x] Documentation - The tutorial style documentation has been updated to explain changes & new features. No changes were required.
- [x] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
