### PR TITLE
Fix xy angle sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This Changelog tracks all past changes to this project as well as details about 
 - `added` proper physics simulation of circuits using qiskit interface #165
 - `added` coupling element which depends on frequency of connected qubits #211
 - `added` model subclass with an arbitrary specified basis change for simulations #220
+- `fixed` wrong direction of rotations on bloch sphere #231
 
 ## Version `1.4` - 23 Dec 2021
 

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -318,7 +318,7 @@ class Instruction:
 
                 xy_angle = comp.params["xy_angle"].get_value()
                 freq_offset = comp.params["freq_offset"].get_value()
-                phase = -xy_angle - freq_offset * ts_off
+                phase = xy_angle - freq_offset * ts_off
                 env = comp.get_shape_values(ts_off, t_end - t_start)
                 env = tf.cast(env, tf.complex128)
 

--- a/test/test_awg.py
+++ b/test/test_awg.py
@@ -61,7 +61,7 @@ def test_AWG_phase_shift() -> None:
     rect.params["xy_angle"] = Qty(phase, "pi")
 
     sigs = generator.generate_signals(rectangle)
-    correct_signal = np.cos(2 * np.pi * lo_freq_q1 * sigs["d1"]["ts"] + phase * np.pi)
+    correct_signal = np.cos(2 * np.pi * lo_freq_q1 * sigs["d1"]["ts"] - phase * np.pi)
     print(sigs["d1"]["values"])
     np.testing.assert_allclose(
         sigs["d1"]["values"].numpy(),

--- a/test/test_awg.py
+++ b/test/test_awg.py
@@ -61,6 +61,7 @@ def test_AWG_phase_shift() -> None:
     rect.params["xy_angle"] = Qty(phase, "pi")
 
     sigs = generator.generate_signals(rectangle)
+    # -phase because of legacy xy_angle sign convention
     correct_signal = np.cos(2 * np.pi * lo_freq_q1 * sigs["d1"]["ts"] - phase * np.pi)
     print(sigs["d1"]["values"])
     np.testing.assert_allclose(

--- a/test/test_instruction.py
+++ b/test/test_instruction.py
@@ -202,4 +202,4 @@ def test_correct_bloch_rotation_direction():
     ideal_gate = exp.pmap.instructions[GATE_NAME].get_ideal_gate(dims=[3])
     propagator = exp.propagators[GATE_NAME].numpy()
     # not equal to one because of imperfections in the propagation
-    assert unitary_infid(ideal_gate, propagator, dims=[3]).numpy()[0] < 0.05
+    np.testing.assert_array_less(unitary_infid(ideal_gate, propagator, dims=[3]).numpy()[0], 0.05)

--- a/test/test_instruction.py
+++ b/test/test_instruction.py
@@ -3,7 +3,6 @@ import pickle
 
 import hjson
 
-from c3.libraries.fidelities import unitary_infid
 from c3.signal.gates import Instruction
 
 from c3.c3objs import Quantity, hjson_decode, hjson_encode
@@ -16,12 +15,12 @@ from c3.model import Model
 import numpy as np
 import pytest
 from c3.libraries.constants import GATES
-from examples.single_qubit_experiment import create_experiment
+
 
 model = Model()
-model.read_config("test_model.cfg")
+model.read_config("test/test_model.cfg")
 generator = Generator()
-generator.read_config("generator2.cfg")
+generator.read_config("test/generator2.cfg")
 
 t_final = 7e-9  # Time for single qubit gates
 sideband = 50e6
@@ -102,7 +101,7 @@ pmap = ParameterMap(model=model, generator=generator, instructions=[instr])
 
 exp = Experiment(pmap)
 
-with open("instruction.pickle", "rb") as filename:
+with open("test/instruction.pickle", "rb") as filename:
     test_data = pickle.load(filename)
 
 
@@ -188,18 +187,3 @@ def test_set_name_ideal():
     assert (instr.ideal == GATES["ry90p"]).all()
     instr.set_name("crzp")
     assert (instr.ideal == GATES["crzp"]).all()
-
-
-@pytest.mark.unit
-def test_correct_bloch_rotation_direction():
-    # makes sure that the rotations on the bloch sphere are in the right direction
-    GATE_NAME = 'ry90p[0]'
-    exp = create_experiment()
-    exp.compute_propagators()
-    # TODO - remove this line after the ideal updating bug gets fixed...
-    exp.pmap.instructions[GATE_NAME].set_ideal(None)
-
-    ideal_gate = exp.pmap.instructions[GATE_NAME].get_ideal_gate(dims=[3])
-    propagator = exp.propagators[GATE_NAME].numpy()
-    # not equal to one because of imperfections in the propagation
-    assert unitary_infid(ideal_gate, propagator, dims=[3]).numpy()[0] < 0.05

--- a/test/test_instruction.py
+++ b/test/test_instruction.py
@@ -3,6 +3,7 @@ import pickle
 
 import hjson
 
+from c3.libraries.fidelities import unitary_infid
 from c3.signal.gates import Instruction
 
 from c3.c3objs import Quantity, hjson_decode, hjson_encode
@@ -15,7 +16,7 @@ from c3.model import Model
 import numpy as np
 import pytest
 from c3.libraries.constants import GATES
-
+from examples.single_qubit_experiment import create_experiment
 
 model = Model()
 model.read_config("test/test_model.cfg")
@@ -187,3 +188,18 @@ def test_set_name_ideal():
     assert (instr.ideal == GATES["ry90p"]).all()
     instr.set_name("crzp")
     assert (instr.ideal == GATES["crzp"]).all()
+
+
+@pytest.mark.unit
+def test_correct_bloch_rotation_direction():
+    # makes sure that the rotations on the bloch sphere are in the right direction
+    GATE_NAME = 'ry90p[0]'
+    exp = create_experiment()
+    exp.compute_propagators()
+    # TODO - remove this line after the ideal updating bug gets fixed...
+    exp.pmap.instructions[GATE_NAME].set_ideal(None)
+
+    ideal_gate = exp.pmap.instructions[GATE_NAME].get_ideal_gate(dims=[3])
+    propagator = exp.propagators[GATE_NAME].numpy()
+    # not equal to one because of imperfections in the propagation
+    assert unitary_infid(ideal_gate, propagator, dims=[3]).numpy()[0] < 0.05

--- a/test/test_model_learning.py
+++ b/test/test_model_learning.py
@@ -46,6 +46,15 @@ def test_model_learning() -> None:
     exp.pmap.set_opt_map(
         [[tuple(par) for par in pset] for pset in cfg.pop("exp_opt_map")]
     )
+
+    # -phase because of legacy xy_angle sign convention
+    for instruction in exp.pmap.instructions.values():
+        for comp in instruction.comps.values():
+            for pulse in comp.values():
+                if "xy_angle" in pulse.params:
+                    pulse.params["xy_angle"] *= -1
+
+
     opt = ModelLearning(**cfg, pmap=exp.pmap)
     opt.set_exp(exp)
     opt.set_created_by(OPT_CONFIG_FILE_NAME)

--- a/test/test_tunable_coupler.py
+++ b/test/test_tunable_coupler.py
@@ -283,6 +283,13 @@ crzp.comps["Q2"]["carrier"].params["framechange"].set_value(framechange_q2)
 parameter_map = PMap(instructions=[crzp], model=model, generator=generator)
 exp = Exp(pmap=parameter_map)
 
+# -phase because of legacy xy_angle sign convention
+for instruction in exp.pmap.instructions.values():
+    for comp in instruction.comps.values():
+        for pulse in comp.values():
+            if "xy_angle" in pulse.params:
+                pulse.params["xy_angle"] *= -1
+
 ##### TESTING ######
 
 with open("test/tunable_coupler_data.pickle", "rb") as filename:


### PR DESCRIPTION
## What
This PR fixes the wrong sign that was used for the `xy_angle` in the `phase` in the `Instruction` class.

## Why
Makes rotations on the bloch sphere be in the correct direction. Closes #231

## How
Removed minus sign.

## Remarks
None

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [x] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [x] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
