### PR TITLE
Add gate name setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This Changelog tracks all past changes to this project as well as details about 
 - `added` proper physics simulation of circuits using qiskit interface #165
 - `added` coupling element which depends on frequency of connected qubits #211
 - `added` model subclass with an arbitrary specified basis change for simulations #220
+- `fixed` bug where changing a gate's name didn't change its ideal gate #233
 
 ## Version `1.4` - 23 Dec 2021
 

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -75,9 +75,17 @@ class Instruction:
 
         self._timings: Dict[str, tuple] = dict()
 
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> str:
+        self.set_name(name)
+
     def as_openqasm(self) -> dict:
         asdict: Dict[str, Any] = {
-            "name": self.name,
+            "name": self._name,
             "qubits": self.targets,
             "params": self.params,
         }
@@ -86,7 +94,7 @@ class Instruction:
         return asdict
 
     def set_name(self, name, ideal=None):
-        self.name = name
+        self._name = name
         self.set_ideal(ideal)
 
     def set_ideal(self, ideal):
@@ -95,7 +103,7 @@ class Instruction:
         else:
             gate_list = []
             # legacy use
-            for key in self.name.split(":"):
+            for key in self._name.split(":"):
                 if key in GATES:
                     gate_list.append(GATES[key])
                 else:
@@ -130,8 +138,8 @@ class Instruction:
 
     def get_key(self) -> str:
         if self.targets is None:
-            return self.name
-        return self.name + str(self.targets)
+            return self._name
+        return self._name + str(self.targets)
 
     def asdict(self) -> dict:
         components = {}  # type:ignore
@@ -310,7 +318,6 @@ class Instruction:
             t_start, t_end = self.get_timings(chan, comp_name)
             ts_off = ts - t_start
             if isinstance(comp, Envelope):
-
                 amp_re = comp.params["amp"].get_value()
                 amp = tf.complex(amp_re, tf.zeros_like(amp_re))
 

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -13,6 +13,29 @@ from c3.utils.tf_utils import tf_project_to_comp
 from c3.signal.pulse import components as comp_lib
 
 
+def _from_dict_get_name_back_compat(cfg: dict, def_name: str) -> str:
+    """
+    Method to use in from_dict to get the name of the Instruction in a backwards compatible manner.
+
+    Parameters
+    ----------
+    cfg: dict
+        Configuration dictionary, including 'name' or '_name' key.
+    def_name: str
+        Name to give if no name is found in the configuration.
+
+    Returns
+    -------
+    Name of the instruction
+    """
+    if "name" in cfg:
+        return cfg["name"]
+    if "_name" in cfg:
+        return cfg["_name"]
+
+    return def_name
+
+
 class Instruction:
     """
     Collection of components making up the control signal for a line.
@@ -162,7 +185,7 @@ class Instruction:
 
     def from_dict(self, cfg, name=None):
         self.__init__(
-            name=cfg["name"] if "name" in cfg else name,
+            name=_from_dict_get_name_back_compat(cfg, name),
             targets=cfg["targets"] if "targets" in cfg else None,
             params=cfg["params"] if "params" in cfg else None,
             ideal=np.array(cfg["ideal"]) if "ideal" in cfg else None,

--- a/c3/signal/gates.py
+++ b/c3/signal/gates.py
@@ -148,6 +148,10 @@ class Instruction:
             for key, comp in item.items():
                 components[chan][key] = comp.asdict()
         out_dict = copy.deepcopy(self.__dict__)
+
+        out_dict["name"] = out_dict["_name"]
+        out_dict.pop("_name")
+
         out_dict["ideal"] = out_dict["ideal"]
         out_dict.pop("_timings")
         out_dict.pop("t_start")

--- a/test/test_instruction.py
+++ b/test/test_instruction.py
@@ -182,8 +182,10 @@ def test_str_conversion():
 
 @pytest.mark.unit
 def test_set_name_ideal():
-    """Check that asigning a name of a specific gate from the constants updates the ideal unitary."""
+    """Check that assigning a name of a specific gate from the constants updates the ideal unitary."""
     instr.set_name("ry90p")
     assert (instr.ideal == GATES["ry90p"]).all()
     instr.set_name("crzp")
     assert (instr.ideal == GATES["crzp"]).all()
+    instr.name = 'ry90p'
+    assert (instr.ideal == GATES["ry90p"]).all()


### PR DESCRIPTION
## What
Adds a setter/getter for the `Instruction.name` attribute (in a backwards compatible manner)

## Why
When changing name directly ideal gate does not change accordingly - Closes #233

## How
Implemented getter/setter and changed current `name` attribute to be `_name`. Also made the exporting/importing still work with this change.

## Remarks
Should not break anything and be totally transparent.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [x] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [x] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
