### PR TITLE
Fix silent OOB params post-optimization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This Changelog tracks all past changes to this project as well as details about 
 - `added` coupling element which depends on frequency of connected qubits #211
 - `added` model subclass with an arbitrary specified basis change for simulations #220
 - `fixed` wrong direction of rotations on bloch sphere #231
+- `fixed` error is raised if optimizer gives OOB results #235
 
 ## Version `1.4` - 23 Dec 2021
 

--- a/c3/c3objs.py
+++ b/c3/c3objs.py
@@ -9,6 +9,10 @@ from tensorflow.python.framework import ops
 import copy
 
 
+class QuantityOOBError(ValueError):
+    pass
+
+
 class C3obj:
     """
     Represents an abstract object with parameters. To be inherited from.
@@ -282,7 +286,7 @@ class Quantity:
         )
 
         if np.any(tf.math.abs(tmp) > tf.constant(1.0, tf.float64)):
-            raise ValueError(
+            raise QuantityOOBError(
                 f"Value {num3str(val.numpy())}{self.unit} out of bounds for quantity with "
                 f"min_val: {num3str(self.get_limits()[0])}{self.unit} and "
                 f"max_val: {num3str(self.get_limits()[1])}{self.unit}",

--- a/c3/c3objs.py
+++ b/c3/c3objs.py
@@ -285,7 +285,15 @@ class Quantity:
             2 * (tf.reshape(val, self.shape) * self.pref - self.offset) / self.scale - 1
         )
 
-        if np.any(tf.math.abs(tmp) > tf.constant(1.0, tf.float64)):
+        const_1 = tf.constant(1.0, tf.float64)
+        if np.any(
+            tf.math.logical_and(
+                tf.math.abs(tmp) > const_1,
+                tf.math.logical_not(
+                    tf.experimental.numpy.isclose(tf.math.abs(tmp), const_1)
+                ),
+            )
+        ):
             raise QuantityOOBException(
                 f"Value {num3str(val.numpy())}{self.unit} out of bounds for quantity with "
                 f"min_val: {num3str(self.get_limits()[0])}{self.unit} and "

--- a/c3/c3objs.py
+++ b/c3/c3objs.py
@@ -9,7 +9,7 @@ from tensorflow.python.framework import ops
 import copy
 
 
-class QuantityOOBError(ValueError):
+class QuantityOOBException(ValueError):
     pass
 
 
@@ -286,7 +286,7 @@ class Quantity:
         )
 
         if np.any(tf.math.abs(tmp) > tf.constant(1.0, tf.float64)):
-            raise QuantityOOBError(
+            raise QuantityOOBException(
                 f"Value {num3str(val.numpy())}{self.unit} out of bounds for quantity with "
                 f"min_val: {num3str(self.get_limits()[0])}{self.unit} and "
                 f"max_val: {num3str(self.get_limits()[1])}{self.unit}",

--- a/c3/optimizers/optimalcontrol.py
+++ b/c3/optimizers/optimalcontrol.py
@@ -2,14 +2,20 @@
 
 import os
 import shutil
+
 import tensorflow as tf
 from typing import Callable, List
 
 from c3.optimizers.optimizer import Optimizer
+from c3.parametermap import ParameterMapOOBUpdateException
 from c3.utils.utils import log_setup
 
 from c3.libraries.algorithms import algorithms
 from c3.libraries.fidelities import fidelities
+
+
+class OptResultOOBError(Exception):
+    pass
 
 
 class OptimalControl(Optimizer):
@@ -153,7 +159,16 @@ class OptimalControl(Optimizer):
             )
         except KeyboardInterrupt:
             pass
-        self.load_best(self.logdir + "best_point_" + self.logname)
+
+        try:
+            self.load_best(
+                self.logdir + "best_point_" + self.logname, extend_bounds=False
+            )
+        except ParameterMapOOBUpdateException as e:
+            raise OptResultOOBError(
+                "The optimization resulted in some of the parameters being out of bounds."
+            ) from e
+
         self.end_log()
 
     @tf.function

--- a/c3/optimizers/optimizer.py
+++ b/c3/optimizers/optimizer.py
@@ -101,7 +101,7 @@ class Optimizer:
         """
         self.created_by = config
 
-    def load_best(self, init_point) -> None:
+    def load_best(self, init_point, extend_bounds=True) -> None:
         """
         Load a previous parameter point to start the optimization from. Legacy wrapper.
         Method moved to Parametermap.
@@ -110,9 +110,11 @@ class Optimizer:
         ----------
         init_point : str
             File location of the initial point
-
+        extend_bounds: bool
+            Whether or not to allow the loaded optimal parameters' bounds to be extended if they exceed those specified.
+            Set to True for backwards compatibility, should generally be False.
         """
-        self.pmap.load_values(init_point)
+        self.pmap.load_values(init_point, extend_bounds=extend_bounds)
 
     def start_log(self) -> None:
         """

--- a/c3/optimizers/optimizer.py
+++ b/c3/optimizers/optimizer.py
@@ -101,7 +101,7 @@ class Optimizer:
         """
         self.created_by = config
 
-    def load_best(self, init_point, extend_bounds=True) -> None:
+    def load_best(self, init_point, extend_bounds=False) -> None:
         """
         Load a previous parameter point to start the optimization from. Legacy wrapper.
         Method moved to Parametermap.
@@ -112,7 +112,6 @@ class Optimizer:
             File location of the initial point
         extend_bounds: bool
             Whether or not to allow the loaded optimal parameters' bounds to be extended if they exceed those specified.
-            Set to True for backwards compatibility, should generally be False.
         """
         self.pmap.load_values(init_point, extend_bounds=extend_bounds)
 

--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -70,7 +70,7 @@ class ParameterMap:
     def update_parameters(self):
         self.__initialize_parameters()
 
-    def load_values(self, init_point, extend_bounds=True):
+    def load_values(self, init_point, extend_bounds=False):
         """
         Load a previous parameter point to start the optimization from.
 

--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -5,11 +5,13 @@ import hjson
 import copy
 import numpy as np
 import tensorflow as tf
-from c3.c3objs import Quantity, hjson_decode, hjson_encode
+from c3.c3objs import Quantity, hjson_decode, hjson_encode, QuantityOOBException
 from c3.signal.gates import Instruction
 from typing import Union
 from tensorflow.errors import InvalidArgumentError
 
+class ParameterMapOOBUpdateException(Exception):
+    pass
 
 class ParameterMap:
     """
@@ -66,7 +68,7 @@ class ParameterMap:
     def update_parameters(self):
         self.__initialize_parameters()
 
-    def load_values(self, init_point):
+    def load_values(self, init_point, extend_bounds=True):
         """
         Load a previous parameter point to start the optimization from.
 
@@ -74,14 +76,16 @@ class ParameterMap:
         ----------
         init_point : str
             File location of the initial point
-
+        extend_bounds: bool
+            Whether or not to allow the loaded parameters' bounds to be extended if they exceed those specified.
         """
         with open(init_point) as init_file:
             best = hjson.load(init_file, object_pairs_hook=hjson_decode)
 
         best_opt_map = best["opt_map"]
         init_p = best["optim_status"]["params"]
-        self.set_parameters(init_p, best_opt_map, extend_bounds=True)
+
+        self.set_parameters(init_p, best_opt_map, extend_bounds=extend_bounds)
 
     def store_values(self, path: str, optim_status=None) -> None:
         """
@@ -308,9 +312,9 @@ class ParameterMap:
                     raise Exception(f"C3:ERROR:{key} not defined.") from ve
                 try:
                     par.set_value(values[val_indx], extend_bounds=extend_bounds)
-                except (ValueError, InvalidArgumentError) as ve:
+                except (QuantityOOBException, InvalidArgumentError) as ve:
                     try:
-                        raise Exception(
+                        raise ParameterMapOOBUpdateException(
                             f"C3:ERROR:Trying to set {key} "
                             f"to value {values[val_indx]} "
                             f"but has to be within {par.offset} .."

--- a/c3/parametermap.py
+++ b/c3/parametermap.py
@@ -10,8 +10,10 @@ from c3.signal.gates import Instruction
 from typing import Union
 from tensorflow.errors import InvalidArgumentError
 
+
 class ParameterMapOOBUpdateException(Exception):
     pass
+
 
 class ParameterMap:
     """

--- a/test/test_model_learning.py
+++ b/test/test_model_learning.py
@@ -54,7 +54,6 @@ def test_model_learning() -> None:
                 if "xy_angle" in pulse.params:
                     pulse.params["xy_angle"] *= -1
 
-
     opt = ModelLearning(**cfg, pmap=exp.pmap)
     opt.set_exp(exp)
     opt.set_created_by(OPT_CONFIG_FILE_NAME)

--- a/test/test_optimalcontrol.py
+++ b/test/test_optimalcontrol.py
@@ -1,10 +1,6 @@
-import os
-import tempfile
-
 import numpy as np
 import pytest
 
-import c3.libraries.algorithms as algorithms
 import c3.libraries.fidelities as fidelities
 from c3.optimizers.optimalcontrol import OptimalControl, OptResultOOBError
 from examples.single_qubit_experiment import create_experiment
@@ -12,8 +8,6 @@ from examples.single_qubit_experiment import create_experiment
 
 @pytest.mark.integration
 def test_raises_OOB_for_bad_optimizer() -> None:
-    np.random.seed(0)
-
     exp = create_experiment()
     exp.set_opt_gates(["rx90p[0]"])
 
@@ -32,17 +26,16 @@ def test_raises_OOB_for_bad_optimizer() -> None:
 
     exp.pmap.set_opt_map(gateset_opt_map)
 
-    log_dir = os.path.join(tempfile.TemporaryDirectory().name, "c3logs")
-    cmaes_options = {"spread": 1, "maxiter": 5}
+    def bad_alg(x_init, fun, *args, **kwargs):
+        res = np.array([x * -99 for x in x_init])
+        fun(res)
+        return res
 
     opt = OptimalControl(
-        dir_path=log_dir,
         fid_func=fidelities.unitary_infid_set,
         fid_subspace=["Q1"],
         pmap=exp.pmap,
-        algorithm=algorithms.cmaes,
-        options=cmaes_options,
-        run_name="OOB_CMAES_opt",
+        algorithm=bad_alg,
     )
 
     exp.set_opt_gates(opt_gates)

--- a/test/test_optimalcontrol.py
+++ b/test/test_optimalcontrol.py
@@ -41,8 +41,5 @@ def test_raises_OOB_for_bad_optimizer() -> None:
     exp.set_opt_gates(opt_gates)
     opt.set_exp(exp)
 
-    try:
+    with pytest.raises(OptResultOOBError):
         opt.optimize_controls()
-        assert False, "Should have raised OptResultOOBError."
-    except OptResultOOBError:
-        pass

--- a/test/test_optimalcontrol.py
+++ b/test/test_optimalcontrol.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import c3.libraries.algorithms as algorithms
+import c3.libraries.fidelities as fidelities
+from c3.optimizers.optimalcontrol import OptimalControl, OptResultOOBError
+from examples.single_qubit_experiment import create_experiment
+
+
+@pytest.mark.integration
+def test_raises_OOB_for_bad_optimizer() -> None:
+    np.random.seed(0)
+
+    exp = create_experiment()
+    exp.set_opt_gates(['rx90p[0]'])
+
+    opt_gates = ["rx90p[0]"]
+    gateset_opt_map = [
+        [
+            ("rx90p[0]", "d1", "carrier", "framechange"),
+        ],
+        [
+            ("rx90p[0]", "d1", "gauss", "amp"),
+        ],
+        [
+            ("rx90p[0]", "d1", "gauss", "freq_offset"),
+        ],
+    ]
+
+    exp.pmap.set_opt_map(gateset_opt_map)
+
+    log_dir = os.path.join(tempfile.TemporaryDirectory().name, "c3logs")
+    cmaes_options = {'spread': 1, 'maxiter': 5}
+
+    opt = OptimalControl(
+        dir_path=log_dir,
+        fid_func=fidelities.unitary_infid_set,
+        fid_subspace=["Q1"],
+        pmap=exp.pmap,
+        algorithm=algorithms.cmaes,
+        options=cmaes_options,
+        run_name="OOB_CMAES_opt"
+    )
+
+    exp.set_opt_gates(opt_gates)
+    opt.set_exp(exp)
+
+    try:
+        opt.optimize_controls()
+        assert False, 'Should have raised OptResultOOBError.'
+    except OptResultOOBError:
+        pass

--- a/test/test_optimalcontrol.py
+++ b/test/test_optimalcontrol.py
@@ -15,7 +15,7 @@ def test_raises_OOB_for_bad_optimizer() -> None:
     np.random.seed(0)
 
     exp = create_experiment()
-    exp.set_opt_gates(['rx90p[0]'])
+    exp.set_opt_gates(["rx90p[0]"])
 
     opt_gates = ["rx90p[0]"]
     gateset_opt_map = [
@@ -33,7 +33,7 @@ def test_raises_OOB_for_bad_optimizer() -> None:
     exp.pmap.set_opt_map(gateset_opt_map)
 
     log_dir = os.path.join(tempfile.TemporaryDirectory().name, "c3logs")
-    cmaes_options = {'spread': 1, 'maxiter': 5}
+    cmaes_options = {"spread": 1, "maxiter": 5}
 
     opt = OptimalControl(
         dir_path=log_dir,
@@ -42,7 +42,7 @@ def test_raises_OOB_for_bad_optimizer() -> None:
         pmap=exp.pmap,
         algorithm=algorithms.cmaes,
         options=cmaes_options,
-        run_name="OOB_CMAES_opt"
+        run_name="OOB_CMAES_opt",
     )
 
     exp.set_opt_gates(opt_gates)
@@ -50,6 +50,6 @@ def test_raises_OOB_for_bad_optimizer() -> None:
 
     try:
         opt.optimize_controls()
-        assert False, 'Should have raised OptResultOOBError.'
+        assert False, "Should have raised OptResultOOBError."
     except OptResultOOBError:
         pass

--- a/test/test_parameter_map.py
+++ b/test/test_parameter_map.py
@@ -256,7 +256,7 @@ def test_parameter_extend() -> None:
     Test the setting in optimizer format. Parameter is out of bounds for the
     original pmap and should be extended.
     """
-    pmap.load_values("test/sample_optim_log.c3log")
+    pmap.load_values("test/sample_optim_log.c3log",extend_bounds=True)
     np.testing.assert_almost_equal(
         pmap.get_parameter(("rx90p[0]", "d1", "gauss", "freq_offset")).numpy(),
         -82997604.24565414,


### PR DESCRIPTION
## What
Makes it be so an error is raised if an optimizer gives OOB parameters instead of it failing silently.

## Why
Makes optimizers raise an error if they give OOB results. Closes #235

## How
Made an error be raised and made the errors along the way be more explicit.

## Remarks
Should not break anything and be totally backwards compatible but if something does break it means it was GIGO (garbage in->garbage out) in the first place.

## Checklist
Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. Check the [Contribution Guidelines](https://github.com/q-optimize/c3/blob/dev/CONTRIBUTING.md) for more details. You can mark an item as complete with the `- [x]` prefix

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [x] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [x] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [x] Changelog - A short note on this PR has been added to the Upcoming Release section
